### PR TITLE
Bitset refactor

### DIFF
--- a/src/EvoTrees.jl
+++ b/src/EvoTrees.jl
@@ -15,7 +15,7 @@ include("loss.jl")
 include("eval.jl")
 include("predict.jl")
 include("tree_vector.jl")
-include("histogram.jl")
+include("find_split.jl")
 include("MLJ.jl")
 
 end # module

--- a/src/find_split.jl
+++ b/src/find_split.jl
@@ -42,7 +42,7 @@ function update_bags!(bins, set)
     end
 end
 
-function find_histogram(bins::Vector{BitSet}, δ::Vector{S}, δ²::Vector{S}, 𝑤::Vector{S}, ∑δ::S, ∑δ²::S, ∑𝑤::S, params::EvoTreeRegressor, info::SplitInfo{S, Int}, track::SplitTrack{S}, edges, set::BitSet) where {S<:AbstractFloat}
+function find_split_bitset!(bins::Vector{BitSet}, δ::Vector{S}, δ²::Vector{S}, 𝑤::Vector{S}, ∑δ::S, ∑δ²::S, ∑𝑤::S, params::EvoTreeRegressor, info::SplitInfo{S, Int}, track::SplitTrack{S}, edges, set::BitSet) where {S<:AbstractFloat}
 
     info.gain = get_gain(params.loss, ∑δ, ∑δ², ∑𝑤, params.λ)
 

--- a/src/find_split.jl
+++ b/src/find_split.jl
@@ -4,7 +4,7 @@
 function get_edges(X, nbins=250)
     edges = Vector{Vector}(undef, size(X,2))
     @threads for i in 1:size(X, 2)
-        edges[i] = unique(quantile(view(X, :,i), (0:nbins)/nbins))[2:(end-1)]
+        edges[i] = unique(quantile(view(X, :,i), (0:nbins)/nbins))[2:end]
         if length(edges[i]) == 0
             edges[i] = [minimum(view(X, :,i))]
         end
@@ -61,10 +61,10 @@ function find_split_bitset!(bins::Vector{BitSet}, δ::Vector{S}, δ²::Vector{S}
     # build histogram
     @inbounds for i in set
         bin = 1
+        # println("i: ", i, "bins[bin]", bins[bin])
         @inbounds while !(i in bins[bin])
             bin += 1
         end
-
         hist_δ[bin] += δ[i]
         hist_δ²[bin] += δ²[i]
         hist_𝑤[bin] += 𝑤[i]
@@ -79,7 +79,6 @@ function find_split_bitset!(bins::Vector{BitSet}, δ::Vector{S}, δ²::Vector{S}
         track.∑𝑤R -= hist_𝑤[bin]
         update_track!(params.loss, track, params.λ)
 
-        # if gain > info.gain && ∑𝑤R > zero(S)
         if track.gain > info.gain && track.∑𝑤L >= params.min_weight && track.∑𝑤R >= params.min_weight
             info.gain = track.gain
             info.gainL = track.gainL

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -50,6 +50,6 @@ end
 
 # prediction in Leaf - QuantileRegression
 function pred_leaf(loss::S, node::TrainNode, params::EvoTreeRegressor, δ²) where {S<:QuantileRegression, T<:AbstractFloat}
-    pred = params.η * quantile(δ², params.α) / (1 + params.λ)
+    pred = params.η * quantile(δ²[collect(node.𝑖)], params.α) / (1 + params.λ)
     return pred
 end

--- a/src/struct.jl
+++ b/src/struct.jl
@@ -132,7 +132,7 @@ function EvoTreeRegressorR(
 end
 
 # single tree is made of a root node that containes nested nodes and leafs
-struct TrainNode{T<:AbstractFloat, I<:AbstractArray{Int, 1}, J<:AbstractArray{Int, 1}, S<:Int}
+struct TrainNode{T<:AbstractFloat, I<:BitSet, J<:AbstractArray{Int, 1}, S<:Int}
     depth::S
     ∑δ::T
     ∑δ²::T

--- a/src/tree_vector.jl
+++ b/src/tree_vector.jl
@@ -50,25 +50,6 @@ function get_max_gain(splits::Vector{SplitInfo{Float64,Int}})
     return best
 end
 
-function get_edges(X, nbins=250)
-    edges = Vector{Vector}(undef, size(X,2))
-    @threads for i in 1:size(X, 2)
-        edges[i] = unique(quantile(view(X, :,i), (0:nbins)/nbins))[2:(end-1)]
-        if length(edges[i]) == 0
-            edges[i] = [minimum(view(X, :,i))]
-        end
-    end
-    return edges
-end
-
-function binarize(X, edges)
-    X_bin = zeros(UInt8, size(X))
-    @threads for i in 1:size(X, 2)
-        X_bin[:,i] = searchsortedlast.(Ref(edges[i]), view(X,:,i)) .+ 1
-    end
-    X_bin
-end
-
 # grow_gbtree
 function grow_gbtree(X::AbstractArray{R, 2}, Y::AbstractArray{T, 1}, params::EvoTreeRegressor;
     X_eval::AbstractArray{R, 2} = Array{R, 2}(undef, (0,0)), Y_eval::AbstractArray{T, 1} = Array{Float64, 1}(undef, 0),

--- a/src/tree_vector.jl
+++ b/src/tree_vector.jl
@@ -13,7 +13,7 @@ function grow_tree(bags::Vector{Vector{BitSet}}, δ::AbstractArray{T, 1}, δ²::
         for id in active_id
             node = train_nodes[id]
             if tree_depth == params.max_depth || node.∑𝑤 <= params.min_weight
-                push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, view(δ², node.𝑖))))
+                push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, δ²)))
             else
                 @threads for feat in node.𝑗
                     find_split_bitset!(bags[feat], δ, δ², 𝑤, node.∑δ::T, node.∑δ²::T, node.∑𝑤::T, params, splits[feat], tracks[feat], edges[feat], node.𝑖)
@@ -31,7 +31,7 @@ function grow_tree(bags::Vector{Vector{BitSet}}, δ::AbstractArray{T, 1}, δ²::
                     push!(next_active_id, leaf_count + 2)
                     leaf_count += 2
                 else
-                    push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, view(δ², node.𝑖))))
+                    push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, δ²)))
                 end # end of single node split search
             end
         end # end of loop over active ids for a given depth

--- a/src/tree_vector.jl
+++ b/src/tree_vector.jl
@@ -18,7 +18,7 @@ function grow_tree(X::AbstractArray{R, 2}, δ::AbstractArray{T, 1}, δ²::Abstra
                 node_size = size(node.𝑖, 1)
                 @threads for feat in node.𝑗
                     sortperm!(view(perm_ini, 1:node_size, feat), view(X, node.𝑖, feat), alg = QuickSort, initialized = false)
-                    find_split!(view(X, view(node.𝑖, view(perm_ini, 1:node_size, feat)), feat), view(δ, view(node.𝑖, view(perm_ini, 1:node_size, feat))) , view(δ², view(node.𝑖, view(perm_ini, 1:node_size, feat))), view(𝑤, view(node.𝑖, view(perm_ini, 1:node_size, feat))), node.∑δ, node.∑δ², node.∑𝑤, params, splits[feat], tracks[feat], X_edges[feat])
+                    find_split_bitset!(view(X, view(node.𝑖, view(perm_ini, 1:node_size, feat)), feat), view(δ, view(node.𝑖, view(perm_ini, 1:node_size, feat))) , view(δ², view(node.𝑖, view(perm_ini, 1:node_size, feat))), view(𝑤, view(node.𝑖, view(perm_ini, 1:node_size, feat))), node.∑δ, node.∑δ², node.∑𝑤, params, splits[feat], tracks[feat], X_edges[feat])
                 end
                 # assign best split
                 best = get_max_gain(splits)
@@ -283,47 +283,4 @@ function grow_gbtree!(model::GBTree, X::AbstractArray{R, 2}, Y::AbstractArray{T,
         model.metric.metric .= metric_best.metric
     end
     return model
-end
-
-# find best split
-function find_split!(x::AbstractArray{T, 1}, δ::AbstractArray{Float64, 1}, δ²::AbstractArray{Float64, 1}, 𝑤::AbstractArray{Float64, 1}, ∑δ, ∑δ², ∑𝑤, params::EvoTreeRegressor, info::SplitInfo, track::SplitTrack, x_edges) where T<:Real
-
-    info.gain = get_gain(params.loss, ∑δ, ∑δ², ∑𝑤, params.λ)
-
-    track.∑δL = 0.0
-    track.∑δ²L = 0.0
-    track.∑𝑤L = 0.0
-    track.∑δR = ∑δ
-    track.∑δ²R = ∑δ²
-    track.∑𝑤R = ∑𝑤
-
-    @inbounds for i in 1:(size(x, 1) - 1)
-    # @fastmath @inbounds for i in eachindex(x)
-
-        track.∑δL += δ[i]
-        track.∑δ²L += δ²[i]
-        track.∑𝑤L += 𝑤[i]
-        track.∑δR -= δ[i]
-        track.∑δ²R -= δ²[i]
-        track.∑𝑤R -= 𝑤[i]
-
-        @inbounds if x[i] < x[i+1] && track.∑𝑤L >= params.min_weight && track.∑𝑤R >= params.min_weight # check gain only if there's a change in value
-        # @inbounds if x[i] < x[i+1] # check gain only if there's a change in value
-
-            update_track!(params.loss, track, params.λ)
-            if track.gain > info.gain
-                info.gain = track.gain
-                info.gainL = track.gainL
-                info.gainR = track.gainR
-                info.∑δL = track.∑δL
-                info.∑δ²L = track.∑δ²L
-                info.∑𝑤L = track.∑𝑤L
-                info.∑δR = track.∑δR
-                info.∑δ²R = track.∑δ²R
-                info.∑𝑤R = track.∑𝑤R
-                info.cond = x_edges[x[i]]
-                info.𝑖 = i
-            end
-        end
-    end
 end

--- a/src/tree_vector.jl
+++ b/src/tree_vector.jl
@@ -13,7 +13,7 @@ function grow_tree(bags::Vector{Vector{BitSet}}, δ::AbstractArray{T, 1}, δ²::
         for id in active_id
             node = train_nodes[id]
             if tree_depth == params.max_depth || node.∑𝑤 <= params.min_weight
-                push!(tree.nodes, TreeNode(- params.η * node.∑δ / (node.∑δ² + params.λ * node.∑𝑤)))
+                push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, view(δ², node.𝑖))))
             else
                 @threads for feat in node.𝑗
                     find_split_bitset!(bags[feat], δ, δ², 𝑤, node.∑δ::T, node.∑δ²::T, node.∑𝑤::T, params, splits[feat], tracks[feat], edges[feat], node.𝑖)
@@ -31,7 +31,7 @@ function grow_tree(bags::Vector{Vector{BitSet}}, δ::AbstractArray{T, 1}, δ²::
                     push!(next_active_id, leaf_count + 2)
                     leaf_count += 2
                 else
-                    push!(tree.nodes, TreeNode(- params.η * node.∑δ / (node.∑δ² + params.λ * node.∑𝑤)))
+                    push!(tree.nodes, TreeNode(pred_leaf(params.loss, node, params, view(δ², node.𝑖))))
                 end # end of single node split search
             end
         end # end of loop over active ids for a given depth

--- a/test/histogram.jl
+++ b/test/histogram.jl
@@ -7,11 +7,12 @@ using StaticArrays
 using Revise
 using BenchmarkTools
 using EvoTrees
-using EvoTrees: get_gain, get_edges, binarize, get_max_gain, update_grads!, grow_tree, grow_gbtree, SplitInfo, SplitTrack, Tree, TrainNode, TreeNode, Params, predict, predict!, sigmoid
-using EvoTrees: scan, find_bags, find_bags_direct, scan, find_histogram, intersect_test, update_bags!, update_bags_intersect
+using EvoTrees: get_gain, get_edges, binarize, get_max_gain, update_grads!, grow_tree, grow_gbtree, SplitInfo, SplitTrack, Tree, TrainNode, TreeNode, EvoTreeRegressor, predict, predict!, sigmoid
+using EvoTrees: find_bags, find_split_bitset!, update_bags!
 
 # prepare a dataset
-features = rand(100_000, 100)
+# features = rand(100_000, 100)
+features = rand(100, 10)
 
 X = features
 Y = rand(size(X, 1))
@@ -28,25 +29,19 @@ X_train, X_eval = X[𝑖_train, :], X[𝑖_eval, :]
 Y_train, Y_eval = Y[𝑖_train], Y[𝑖_eval]
 
 # set parameters
-loss = :linear
-nrounds = 10
-λ = 1.0
-γ = 0.0
-η = 0.5
-max_depth = 5
-min_weight = 5.0
-rowsample = 1.0
-colsample = 1.0
-nbins = 32
-# params1 = Params(nrounds, λ, γ, η, max_depth, min_weight, :linear)
-params1 = Params(:linear, nrounds, λ, γ, 1.0, 5, min_weight, rowsample, colsample, nbins)
+params1 = EvoTreeRegressor(
+    loss=:linear, metric=:mse,
+    nrounds=10, nbins=100,
+    λ = 0.5, γ=0.1, η=0.01,
+    max_depth = 5, min_weight = 1.0,
+    rowsample=0.5, colsample=1.0)
 
 # initial info
 δ, δ² = zeros(size(X, 1)), zeros(size(X, 1))
 𝑤 = ones(size(X, 1))
 pred = zeros(size(Y, 1))
 # @time update_grads!(Val{params1.loss}(), pred, Y, δ, δ²)
-update_grads!(Val{params1.loss}(), pred, Y, δ, δ², 𝑤)
+update_grads!(params1.loss, params1.α, pred, Y, δ, δ², 𝑤)
 ∑δ, ∑δ², ∑𝑤 = sum(δ), sum(δ²), sum(𝑤)
 gain = get_gain(∑δ, ∑δ², ∑𝑤, params1.λ)
 
@@ -117,13 +112,16 @@ sqrt(mean((pred_train .- Y_train) .^ 2))
 #############################################
 
 𝑖_set = BitSet(𝑖);
+@time bags = prep2(X, params1);
 
-feat = 9
-find_histogram(bags[feat], δ, δ², 𝑤, ∑δ, ∑δ², ∑𝑤, params1.λ, splits[feat], tracks[feat], edges[feat], train_nodes[feat].𝑖)
-@time find_histogram(bags[1], δ, δ², 𝑤, ∑δ, ∑δ², ∑𝑤, params1.λ, splits[1], tracks[1], edges[1], train_nodes[1].𝑖)
-@btime find_histogram($bags[1], $δ, $δ², $𝑤, $∑δ, $∑δ², $∑𝑤, $params1.λ, $splits[1], $tracks[1], $edges[1], $train_nodes[1].𝑖)
+feat = 1
+typeof(bags[feat][1])
+train_nodes[1] = TrainNode(1, ∑δ, ∑δ², ∑𝑤, gain, BitSet(𝑖), 𝑗)
+find_histogram(bags[feat], δ, δ², 𝑤, ∑δ, ∑δ², ∑𝑤, params1, splits[feat], tracks[feat], edges[feat], train_nodes[1].𝑖)
+@time find_histogram(bags[1], δ, δ², 𝑤, ∑δ, ∑δ², ∑𝑤, params1, splits[1], tracks[1], edges[1], train_nodes[1].𝑖)
+@btime find_histogram($bags[1], $δ, $δ², $𝑤, $∑δ, $∑δ², $∑𝑤, $params1, $splits[1], $tracks[1], $edges[1], $train_nodes[1].𝑖)
 
-
+splits[feat]
 
 new_bags = Vector{Vector{BitSet}}(undef, length(bags))
 for i in 1:length(new_bags)

--- a/test/random.jl
+++ b/test/random.jl
@@ -26,7 +26,7 @@ params1 = EvoTreeRegressor(
     nrounds=10,
     λ = 0.0, γ=0.0, η=0.1,
     max_depth = 5, min_weight = 1.0,
-    rowsample=1.0, colsample=1.0, nbins=50)
+    rowsample=1.0, colsample=1.0, nbins=25)
 
 @time model = grow_gbtree(X_train, Y_train, params1, X_eval = X_eval, Y_eval = Y_eval, print_every_n = 1)
 @time pred_train = predict(model, X_train)

--- a/test/random.jl
+++ b/test/random.jl
@@ -25,8 +25,8 @@ params1 = EvoTreeRegressor(
     loss=:linear, metric=:mae,
     nrounds=10,
     λ = 0.0, γ=0.0, η=0.1,
-    max_depth = 5, min_weight = 1.0,
-    rowsample=1.0, colsample=1.0, nbins=25)
+    max_depth = 6, min_weight = 1.0,
+    rowsample=1.0, colsample=1.0, nbins=20)
 
 @time model = grow_gbtree(X_train, Y_train, params1, X_eval = X_eval, Y_eval = Y_eval, print_every_n = 1)
 @time pred_train = predict(model, X_train)
@@ -37,7 +37,7 @@ params1 = EvoTreeRegressor(
     loss=:logistic,
     nrounds=10,
     λ = 0.0, γ=0.0, η=0.1,
-    max_depth = 5, min_weight = 1.0,
+    max_depth = 6, min_weight = 1.0,
     rowsample=1.0, colsample=1.0, nbins=50)
 @time model = grow_gbtree(X_train, Y_train, params1, X_eval = X_eval, Y_eval = Y_eval, print_every_n=1, metric = :logloss)
 @time pred_train = predict(model, X_train)

--- a/test/random.jl
+++ b/test/random.jl
@@ -22,13 +22,13 @@ Y_train, Y_eval = Y[𝑖_train], Y[𝑖_eval]
 
 # train model
 params1 = EvoTreeRegressor(
-    loss=:linear,
+    loss=:linear, metric=:mae,
     nrounds=10,
     λ = 0.0, γ=0.0, η=0.1,
     max_depth = 5, min_weight = 1.0,
     rowsample=1.0, colsample=1.0, nbins=50)
 
-@time model = grow_gbtree(X_train, Y_train, params1, X_eval = X_eval, Y_eval = Y_eval, print_every_n = 1, metric=:mae)
+@time model = grow_gbtree(X_train, Y_train, params1, X_eval = X_eval, Y_eval = Y_eval, print_every_n = 1)
 @time pred_train = predict(model, X_train)
 mean(abs.(pred_train .- Y_train))
 


### PR DESCRIPTION
Move to BitSet histogram approach. 
Significant speedups for limited number of bins (< 64). NBins grater than 100 may result in slowdown. 
To do: add option to switch between the loop over bins or add heuristic to emulate high number of split points (by building N sets of bags for the equivalent of N*nbins behavior). 