### PR TITLE
Fix iteration_parameter declaration

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -29,7 +29,7 @@ MLJModelInterface.selectrows(::EvoTypes, I, A, y) = ((matrix = view(A.matrix, I,
 MLJModelInterface.selectrows(::EvoTypes, I, A) = ((matrix = view(A.matrix, I, :), names = A.names),)
 
 # For EarlyStopping.jl support
-MLJModelInterface.iteration_parameter(::EvoTypes) = :nrounds
+MLJModelInterface.iteration_parameter(::Type{<:EvoTypes}) = :nrounds
 
 function MLJModelInterface.update(model::EvoTypes, verbosity::Integer, fitresult, cache, A, y)
 

--- a/test/MLJ.jl
+++ b/test/MLJ.jl
@@ -36,6 +36,8 @@ mean(abs.(pred_train - selectrows(Y,train)))
 pred_test = predict(mach, selectrows(X,test))
 mean(abs.(pred_test - selectrows(Y,test)))
 
+@test MLJBase.iteration_parameter(EvoTreeRegressor) == :nrounds
+
 
 ##################################################
 ### classif - categorical target


### PR DESCRIPTION
Trait should be defined on *types* not *instances*, but not so at the moment:

```julia
julia> MLJModels.iteration_parameter(booster)
:nrounds

julia> MLJModels.iteration_parameter(typeof(booster))

julia> 
```

This PR fixes this and adds test.