### PR TITLE
Fix MLJ metadata declarations so that new docstrings get written to the MLJ model registry

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -94,11 +94,6 @@ end
 
 
 # Metadata
-const EvoTreeRegressor_desc = "Regression models with various underlying methods: least square, quantile, logistic, gamma (deviance), tweedie (deviance)."
-const EvoTreeClassifier_desc = "Multi-classification with softmax and cross-entropy loss."
-const EvoTreeCount_desc = "Poisson regression fitting λ with deviance minimization."
-const EvoTreeGaussian_desc = "Deprecated - Use EvoTreeMLE with `loss=:normal` instead. Gaussian maximum likelihood of μ and σ."
-const EvoTreeMLE_desc = "Maximum likelihood methods supporting Normal/Gaussian and Logistic distributions."
 
 MMI.metadata_pkg.(
     (EvoTreeRegressor, EvoTreeClassifier, EvoTreeCount, EvoTreeGaussian),

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -119,7 +119,6 @@ MMI.metadata_model(
     target_scitype = AbstractVector{<:MMI.Continuous},
     weights = false,
     path = "EvoTrees.EvoTreeRegressor",
-    descr = EvoTreeRegressor_desc,
 )
 
 MMI.metadata_model(
@@ -131,7 +130,6 @@ MMI.metadata_model(
     target_scitype = AbstractVector{<:MMI.Finite},
     weights = false,
     path = "EvoTrees.EvoTreeClassifier",
-    descr = EvoTreeClassifier_desc,
 )
 
 MMI.metadata_model(
@@ -143,7 +141,6 @@ MMI.metadata_model(
     target_scitype = AbstractVector{<:MMI.Count},
     weights = false,
     path = "EvoTrees.EvoTreeCount",
-    descr = EvoTreeCount_desc,
 )
 
 MMI.metadata_model(
@@ -155,7 +152,6 @@ MMI.metadata_model(
     target_scitype = AbstractVector{<:MMI.Continuous},
     weights = false,
     path = "EvoTrees.EvoTreeGaussian",
-    descr = EvoTreeGaussian_desc,
 )
 
 MMI.metadata_model(
@@ -167,7 +163,6 @@ MMI.metadata_model(
     target_scitype = AbstractVector{<:MMI.Continuous},
     weights = false,
     path = "EvoTrees.EvoTreeMLE",
-    descr = EvoTreeMLE_desc,
 )
 
 """


### PR DESCRIPTION
Currently:

```julia
julia> using MLJModels

julia> doc("EvoTreeClassifier")
  Multi-classification with softmax and cross-entropy loss.
```

This is also an issue for EvoLinear.jl and the fix required is likely the same. 

Follow up required:

- [ ] Update the MLJ model registry