### PR TITLE
Add generic MLJ interface tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
-authors = ["jeremiedb <jeremie.db@evovest.com>"]
 name = "EvoTrees"
 uuid = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
+authors = ["jeremiedb <jeremie.db@evovest.com>"]
 version = "0.13.0"
 
 [deps]
@@ -33,8 +33,9 @@ julia = "1.6"
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestIntegration = "697918b4-fdc1-4f9e-8ff9-929724cee270"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 docs = ["Documenter"]
-test = ["Test", "MLJBase"]
+test = ["Test", "MLJBase", "MLJTestIntegration"]

--- a/test/MLJ.jl
+++ b/test/MLJ.jl
@@ -2,6 +2,46 @@ using StatsBase: sample
 using EvoTrees: sigmoid, logit
 using MLJBase
 
+using MLJTestIntegration
+
+@testset "generic interface tests" begin
+    @testset "EvoTreeRegressor, EvoTreeMLE, EvoTreeGaussian" begin
+        failures, summary = MLJTestIntegration.test(
+            [EvoTreeRegressor, EvoTreeMLE, EvoTreeGaussian],
+            MLJTestIntegration.make_regression()...;
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+    @testset "EvoTreeCount" begin
+        failures, summary = MLJTestIntegration.test(
+            [EvoTreeCount],
+            MLJTestIntegration.make_count()...;
+            mod=@__MODULE__,
+            verbosity=0, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
+    @testset "EvoTreeClassifier" begin
+        for data in [
+            MLJTestIntegration.make_binary(),
+            MLJTestIntegration.make_multiclass(),
+        ]
+            failures, summary = MLJTestIntegration.test(
+                [EvoTreeClassifier],
+                data...;
+                mod=@__MODULE__,
+                verbosity=0, # bump to debug
+                throw=false, # set to true to debug
+            )
+            @test isempty(failures)
+        end
+    end
+end
+
 ##################################################
 ### Regression - small data
 ##################################################


### PR DESCRIPTION
This PR is only a suggestion, as MLJTestIntegration is at an experimental stage. We do have this installed in a couple of other packages. 

 Adding MLJTestIntegration currently adds the entire MLJ stack (MLJTuning, MLJIteration, etc), so it's a bigger (test) dependency than what is currently here. But I expect we will factor out a lighter-weight MLJTestInterface in the near future (and the syntax won't change much, if at all).

The `level=2` tests included here are: 

    •  :model_type: Load model type using `load_path(model_type)` (to check `load_path` trait
       is correctly overloaded).

    •  :model_instance: Create a default instance.

    •  :fitted_machine: Bind instance to data in a machine and fit!. Call report and
       fitted_params on the machine.

    •  :operations: Call implemented operations, such as predict and transform

But I have independently checked that level=4 tests also pass. Do `using MLJTestIntegration; @doc MLJTestIntegration.test` for further details. 