### PR TITLE
Ensure that set of proportions is complete

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -35,7 +35,7 @@ function init_evotree(
             y = UInt32.(CategoricalArrays.levelcode.(yc))
         end
         K = length(levels)
-        μ = T.(log.(proportions(y)))
+        μ = T.(log.(proportions(y, UInt32(1):UInt32(K))))
         μ .-= maximum(μ)
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == GaussianMLE

--- a/src/gpu/fit_gpu.jl
+++ b/src/gpu/fit_gpu.jl
@@ -31,7 +31,7 @@ function init_evotree_gpu(
             y = CuArray(UInt32.(CategoricalArrays.levelcode.(yc)))
         end
         K = length(levels)
-        μ = T.(log.(proportions(y)))
+        μ = T.(log.(proportions(y, UInt32(1):UInt32(K))))
         μ .-= maximum(μ)
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == GaussianMLE

--- a/test/core.jl
+++ b/test/core.jl
@@ -402,7 +402,7 @@ end
     y_train_cat = CategoricalArray(y_train; levels=1:2)
 
     params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3, rng)
-    model_cat = fit_evotree(params1_cat; x_train, y_train=y_train_cat)
+    model_cat = fit_evotree(params1; x_train, y_train=y_train_cat)
 
     preds_cat = EvoTrees.predict(model_cat, x_train)[:, 1]
     @test preds_cat == preds

--- a/test/core.jl
+++ b/test/core.jl
@@ -380,8 +380,6 @@ end
 
 
 @testset "EvoTreeClassifier" begin
-    params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3)
-
     # x_train = Array([
     #     sin.(1:1000) cos.(1:1000)
     #     100 .* cos.(1:1000) 100 .* sin.(1:1000)
@@ -393,8 +391,28 @@ end
     ])
     y_train = repeat(1:2; inner = 1000)
 
+    rng = rand(UInt32)
+    params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3, rng)
     model = fit_evotree(params1; x_train, y_train)
 
     preds = EvoTrees.predict(model, x_train)[:, 1]
     @test !any(isnan.(preds))
+
+    # Categorical array
+    y_train_cat = CategoricalArray(y_train; levels=1:2)
+
+    params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3, rng)
+    model_cat = fit_evotree(params1_cat; x_train, y_train=y_train_cat)
+
+    preds_cat = EvoTrees.predict(model_cat, x_train)[:, 1]
+    @test preds_cat == preds
+
+    # Categorical array with additional levels
+    y_train_cat = CategoricalArray(y_train; levels=1:3)
+
+    params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3, rng)
+    model_cat = fit_evotree(params1; x_train, y_train=y_train_cat)
+
+    preds_cat = EvoTrees.predict(model_cat, x_train)[:, 1]
+    @test preds_cat ≈ preds # differences due to different stream of random numbers
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Statistics
 using EvoTrees
 using EvoTrees: predict
+using CategoricalArrays
 using Random
 using Test
 


### PR DESCRIPTION
I ran into issues when adding the more advanced example in https://github.com/TuringLang/MCMCDiagnosticTools.jl/pull/57. A MWE is
```julia
julia> using EvoTrees, CategoricalArrays

julia> x_train = Array([
               sin.(1:1000) rand(1000)
               100 .* cos.(1:1000) rand(1000) .+ 1 
           ]);

julia> y_train = CategoricalArray(repeat(1:2; inner = 1000); levels=1:3);

julia> params1 = EvoTreeClassifier(; T = Float32, nrounds = 100, eta = 0.3);

julia> fit_evotree(params1_cat; x_train, y_train)
```

Currently the example errors:
```julia
julia> fit_evotree(params1; x_train, y_train)
┌ Info: 
│ EvoTreeClassifier{EvoTrees.Softmax, Float32}
│  - nrounds: 100
│  - lambda: 0.0
│  - gamma: 0.0
│  - eta: 0.3
│  - max_depth: 5
│  - min_weight: 1.0
│  - rowsample: 1.0
│  - colsample: 1.0
│  - nbins: 32
│  - alpha: 0.5
│  - rng: Random.TaskLocalRNG()
└  - device: cpu
ERROR: DimensionMismatch: array could not be broadcast to match destination
Stacktrace:
 [1] check_broadcast_shape
   @ ./broadcast.jl:540 [inlined]
 [2] check_broadcast_axes
   @ ./broadcast.jl:543 [inlined]
 [3] instantiate
   @ ./broadcast.jl:284 [inlined]
 [4] materialize!
   @ ./broadcast.jl:871 [inlined]
 [5] materialize!(dest::SubArray{Float32, 1, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}, bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(identity), Tuple{Vector{Float32}}})
   @ Base.Broadcast ./broadcast.jl:868
 [6] init_evotree(params::EvoTreeClassifier{EvoTrees.Softmax, Float32}; x_train::Matrix{Float64}, y_train::CategoricalVector{Int64, UInt32, Int64, CategoricalValue{Int64, UInt32}, Union{}}, w_train::Nothing, offset_train::Nothing, fnames::Nothing)
   @ EvoTrees ~/.julia/packages/EvoTrees/jGaEI/src/fit.jl:64
 [7] fit_evotree(params::EvoTreeClassifier{EvoTrees.Softmax, Float32}; x_train::Matrix{Float64}, y_train::CategoricalVector{Int64, UInt32, Int64, CategoricalValue{Int64, UInt32}, Union{}}, w_train::Nothing, offset_train::Nothing, x_eval::Nothing, y_eval::Nothing, w_eval::Nothing, offset_eval::Nothing, metric::Nothing, early_stopping_rounds::Int64, print_every_n::Int64, verbosity::Int64, fnames::Nothing, return_logger::Bool)
   @ EvoTrees ~/.julia/packages/EvoTrees/jGaEI/src/fit.jl:332
 [8] top-level scope
   @ REPL[10]:1
 [9] top-level scope
   @ ~/.julia/packages/CUDA/Ey3w2/src/initialization.jl:52
```

Whereas with this PR we get:
```julia
julia> fit_evotree(params1; x_train, y_train)
┌ Info: 
│ EvoTreeClassifier(
│   nrounds = 100, 
│   lambda = 0.0f0, 
│   gamma = 0.0f0, 
│   eta = 0.3f0, 
│   max_depth = 5, 
│   min_weight = 1.0f0, 
│   rowsample = 1.0f0, 
│   colsample = 1.0f0, 
│   nbins = 32, 
│   alpha = 0.5f0, 
│   rng = Random.TaskLocalRNG(), 
└   device = "cpu")
EvoTree{EvoTrees.Softmax, 3, Float32}
 - Contains 101 trees in field `trees` (incl. 1 bias tree).
 - Data input has 2 features.
 - [:fnames, :levels] info accessible in field `info`
```

The problem occurs if one provides a categorical array for target `y` where some levels are missing.