### PR TITLE
Type validation for model parameters

### DIFF
--- a/docs/src/tutorials/classification-iris.md
+++ b/docs/src/tutorials/classification-iris.md
@@ -1,4 +1,4 @@
-# Classication on Iris dataset
+# Classification on Iris dataset
 
 We will use the iris dataset, which is included in the MLDatasets package. This dataset consists of measurements of the sepal length, sepal width, petal length, and petal width for three different types of iris flowers: Setosa, Versicolor, and Virginica.
 

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -193,7 +193,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
 - `max_depth=5`:          Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.
-- `min_weight=0.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
+- `min_weight=0.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
 - `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `nbins=32`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
@@ -307,14 +307,14 @@ EvoTreeClassifier is used to perform multi-class classification, using cross-ent
 - `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.  
 - `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
-- `gamma::T=0.0`:               Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model.
+- `gamma::T=0.0`:               Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `max_depth=5`:                Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.
-- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
+- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
 - `rowsample=1.0`:              Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `colsample=1.0`:              Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
-- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins.
+- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `T=Float32`:                  The float precision on which the model will be trained. One of `Float32` or `Float64`.
 - `rng=123`:                    Either an integer used as a seed to the random number generator or an actual random number generator (`::Random.AbstractRNG`).
 - `device="cpu"`:               Hardware device to use for computations. Can be either `"cpu"` or `"gpu"`.
@@ -426,18 +426,18 @@ EvoTreeCount is used to perform Poisson probabilistic regression on count target
 
 # Hyper-parameters
 
-- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked.
-- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. 
+- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
+- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.  
-- `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
+- `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model. Must be >= 0.
 - `gamma::T=0.0`:               Minimum gain imprvement needed to perform a node split. Higher gamma can result in a more robust model.
 - `max_depth=5`:                Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to 2^max_depth. Typical optimal values are in the 3 to 9 range.
-- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
+- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
 - `rowsample=1.0`:              Proportion of rows that are sampled at each iteration to build the tree. Should be `]0, 1]`.
 - `colsample=1.0`:              Proportion of columns / features that are sampled at each iteration to build the tree. Should be `]0, 1]`.
-- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins.
+- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing).
 - `T=Float32`:                  The float precision on which the model will be trained. One of `Float32` or `Float64`.
 - `rng=123`:                    Either an integer used as a seed to the random number generator or an actual random number generator (`::Random.AbstractRNG`).
@@ -554,18 +554,18 @@ EvoTreeGaussian is used to perform Gaussian probabilistic regression, fitting μ
 
 # Hyper-parameters
 
-- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked.
-- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. 
+- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
+- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.  
 - `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
-- `gamma::T=0.0`:               Minimum gain imprvement needed to perform a node split. Higher gamma can result in a more robust model.
+- `gamma::T=0.0`:               Minimum gain imprvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `max_depth=5`:                Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to 2^max_depth. Typical optimal values are in the 3 to 9 range.
-- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
+- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
 - `rowsample=1.0`:              Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `colsample=1.0`:              Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
-- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins.
+- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 
   !Experimental feature: note that for Gaussian regression, constraints may not be enforce systematically.
 - `T=Float64`:                  The float precision on which the model will be trained. One of `Float32` or `Float64`.
@@ -690,18 +690,18 @@ EvoTreeMLE performs maximum likelihood estimation. Assumed distribution is speci
 `loss=:gaussian`:         Loss to be be minimized during training. One of:
   - `:gaussian` / `:gaussian_mle`
   - `:logistic` / `:logistic_mle`
-- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked.
-- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. 
+- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
+- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.  
 - `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
-- `gamma::T=0.0`:               Minimum gain imprvement needed to perform a node split. Higher gamma can result in a more robust model.
+- `gamma::T=0.0`:               Minimum gain imprvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `max_depth=5`:                Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to 2^max_depth. Typical optimal values are in the 3 to 9 range.
-- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
+- `min_weight=0.0`:             Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
 - `rowsample=1.0`:              Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `colsample=1.0`:              Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
-- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins.
+- `nbins=32`:                   Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 
   !Experimental feature: note that for MLE regression, constraints may not be enforced systematically.
 - `T=Float64`:                  The float precision on which the model will be trained. One of `Float32` or `Float64`.

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -180,11 +180,11 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:tweedie`
   - `:quantile`
   - `:L1`
-- `nrounds=10`:           Number of rounds. It corresponds to the number of trees that will be sequentially stacked.
-- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. 
+- `nrounds=10`:           Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
+- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.   
 - `lambda::T=0.0`:        L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
-- `gamma::T=0.0`:         Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model.
+- `gamma::T=0.0`:         Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `alpha::T=0.5`:         Loss specific parameter in the [0, 1] range:
                             - `:quantile`: target quantile for the regression.
                             - `:L1`: weighting parameters to positive vs negative residuals.
@@ -196,7 +196,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
 - `min_weight=0.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector.
 - `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
-- `nbins=32`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins.
+- `nbins=32`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 
   Only `:linear`, `:logistic`, `:gamma` and `tweedie` losses are supported at the moment.
 - `T=Float32`:            The float precision on which the model will be trained. One of `Float32` or `Float64`.
@@ -303,8 +303,8 @@ EvoTreeClassifier is used to perform multi-class classification, using cross-ent
 
 # Hyper-parameters
 
-- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked.
-- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. 
+- `nrounds=10`:                 Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
+- `eta=0.1`:              Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
   A lower `eta` results in slower learning, requiring a higher `nrounds` but typically improves model performance.  
 - `lambda::T=0.0`:              L2 regularization term on weights. Must be >= 0. Higher lambda can result in a more robust model.
 - `gamma::T=0.0`:               Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model.

--- a/src/models.jl
+++ b/src/models.jl
@@ -44,7 +44,7 @@ end
 function check_args(::Type{<:T}, args::Dict{Symbol,Any}) where {T<:Real}
 
     # Check integer parameters
-    check_parameter(Int, args[:nrounds], 0, typemax(Int), :nrounds)
+    check_parameter(Int, args[:nrounds], 1, typemax(Int), :nrounds)
     check_parameter(Int, args[:max_depth], 1, typemax(Int), :max_depth)
     check_parameter(Int, args[:nbins], 2, 255, :nbins)
 
@@ -470,7 +470,7 @@ function check_args(model::EvoTypes{L,T}) where {L,T<:Real}
 
     # Check integer parameters
     check_parameter(Int, model.max_depth, 1, typemax(Int), :max_depth)
-    check_parameter(Int, model.nrounds, 0, typemax(Int), :nrounds)
+    check_parameter(Int, model.nrounds, 1, typemax(Int), :nrounds)
     check_parameter(Int, model.nbins, 2, 255, :nbins)
 
     # check positive float parameters

--- a/src/models.jl
+++ b/src/models.jl
@@ -29,7 +29,7 @@ function mk_rng(int::Integer, device = "cpu")
 end
 
 # check model parameter if it's valid
-function check_parameter(::Type{<:T}, value, min_value::T, max_value::T, label::Symbol) where {T<:Number}
+function check_parameter(::Type{<:T}, value, min_value::Real, max_value::Real, label::Symbol) where {T<:Number}
     min_value = max(typemin(T), min_value)
     max_value = min(typemax(T), max_value)
     try
@@ -49,14 +49,14 @@ function check_args(::Type{<:T}, args::Dict{Symbol,Any}) where {T<:Real}
     check_parameter(Int, args[:nbins], 2, 255, :nbins)
 
     # check positive float parameters
-    check_parameter(T, args[:lambda], 0.0, typemax(T), :lambda)
-    check_parameter(T, args[:gamma], 0.0, typemax(T), :gamma)
-    check_parameter(T, args[:min_weight], 0.0,typemax(T), :min_weight)
+    check_parameter(T, args[:lambda], zero(T), typemax(T), :lambda)
+    check_parameter(T, args[:gamma], zero(T), typemax(T), :gamma)
+    check_parameter(T, args[:min_weight], zero(T), typemax(T), :min_weight)
 
     # check bounded parameters
-    check_parameter(T, args[:alpha], 0.0, 1.0, :alpha)
-    check_parameter(T, args[:rowsample], eps(T), 1.0, :rowsample)
-    check_parameter(T, args[:colsample], eps(T), 1.0, :colsample)
+    check_parameter(T, args[:alpha], zero(T), one(T), :alpha)
+    check_parameter(T, args[:rowsample], eps(T), one(T), :rowsample)
+    check_parameter(T, args[:colsample], eps(T), one(T), :colsample)
 end
 
 mutable struct EvoTreeRegressor{L<:ModelType,T} <: MMI.Deterministic
@@ -461,4 +461,24 @@ function Base.show(io::IO, config::EvoTypes)
     for fname in fieldnames(typeof(config))
         println(io, " - $fname: $(getfield(config, fname))")
     end
+end
+
+# check model arguments if they are valid (eg, after mutation when tuning hyperparams)
+# Note: does not check consistency of model type and loss selected
+function check_args(model::EvoTypes{L,T}) where {L,T<:Real}
+
+    # Check integer parameters
+    check_parameter(Int, model.max_depth, 1, typemax(Int), :max_depth)
+    check_parameter(Int, model.nrounds, 0, typemax(Int), :nrounds)
+    check_parameter(Int, model.nbins, 2, 255, :nbins)
+
+    # check positive float parameters
+    check_parameter(T, model.lambda, zero(T), typemax(T), :lambda)
+    check_parameter(T, model.gamma, zero(T), typemax(T), :gamma)
+    check_parameter(T, model.min_weight, zero(T), typemax(T), :min_weight)
+
+    # check bounded parameters
+    check_parameter(T, model.alpha, zero(T), one(T), :alpha)
+    check_parameter(T, model.rowsample, eps(T), one(T), :rowsample)
+    check_parameter(T, model.colsample, eps(T), one(T), :colsample)
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -57,6 +57,7 @@ function check_args(::Type{<:T}, args::Dict{Symbol,Any}) where {T<:Real}
     check_parameter(T, args[:alpha], zero(T), one(T), :alpha)
     check_parameter(T, args[:rowsample], eps(T), one(T), :rowsample)
     check_parameter(T, args[:colsample], eps(T), one(T), :colsample)
+    check_parameter(T, args[:eta], eps(T), typemax(T), :eta)
 end
 
 mutable struct EvoTreeRegressor{L<:ModelType,T} <: MMI.Deterministic
@@ -481,4 +482,5 @@ function check_args(model::EvoTypes{L,T}) where {L,T<:Real}
     check_parameter(T, model.alpha, zero(T), one(T), :alpha)
     check_parameter(T, model.rowsample, eps(T), one(T), :rowsample)
     check_parameter(T, model.colsample, eps(T), one(T), :colsample)
+    check_parameter(T, model.eta, eps(T), typemax(T), :eta)
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -162,7 +162,7 @@ mutable struct EvoTreeCount{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::UInt8
+    nbins::Int
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -198,6 +198,8 @@ function EvoTreeCount(; kwargs...)
     L = Poisson
     T = args[:T]
 
+    check_args(T, args)
+
     model = EvoTreeCount{L,T}(
         args[:nrounds],
         T(args[:lambda]),
@@ -207,7 +209,7 @@ function EvoTreeCount(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        convert_parameter(UInt8, args[:nbins], :nbins),
+        args[:nbins],
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],
@@ -230,7 +232,7 @@ mutable struct EvoTreeClassifier{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::UInt8
+    nbins::Int
     alpha::T
     rng::Any
     device::Any
@@ -264,6 +266,8 @@ function EvoTreeClassifier(; kwargs...)
     L = Softmax
     T = args[:T]
 
+    check_args(T, args)
+
     model = EvoTreeClassifier{L,T}(
         args[:nrounds],
         T(args[:lambda]),
@@ -273,7 +277,7 @@ function EvoTreeClassifier(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        convert_parameter(UInt8, args[:nbins], :nbins),
+        args[:nbins],
         T(args[:alpha]),
         args[:rng],
         args[:device],
@@ -295,7 +299,7 @@ mutable struct EvoTreeMLE{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::UInt8
+    nbins::Int
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -342,6 +346,8 @@ function EvoTreeMLE(; kwargs...)
         )
     end
 
+    check_args(T, args)
+
     model = EvoTreeMLE{L,T}(
         args[:nrounds],
         T(args[:lambda]),
@@ -351,7 +357,7 @@ function EvoTreeMLE(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        convert_parameter(UInt8, args[:nbins], :nbins),
+        args[:nbins],
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],
@@ -380,7 +386,7 @@ mutable struct EvoTreeGaussian{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::UInt8
+    nbins::Int
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -415,6 +421,8 @@ function EvoTreeGaussian(; kwargs...)
     L = GaussianMLE
     T = args[:T]
 
+    check_args(T, args)
+
     model = EvoTreeGaussian{L,T}(
         args[:nrounds],
         T(args[:lambda]),
@@ -424,7 +432,7 @@ function EvoTreeGaussian(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        convert_parameter(UInt8, args[:nbins], :nbins),
+        args[:nbins],
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],

--- a/src/models.jl
+++ b/src/models.jl
@@ -28,6 +28,15 @@ function mk_rng(int::Integer, device = "cpu")
     return rng
 end
 
+# check model parameter if it's valid
+function convert_parameter(::Type{<:T},value,label::Symbol) where {T<:Number}
+    try
+        return convert(T,value)
+    catch
+        return error("Invalid value for parameter `$(string(label))`: $value. `$(string(label))` must be of type $T (ie, value between $(typemin(T)) and $(typemax(T))).")
+    end
+end
+
 mutable struct EvoTreeRegressor{L<:ModelType,T} <: MMI.Deterministic
     nrounds::Int
     lambda::T
@@ -37,7 +46,7 @@ mutable struct EvoTreeRegressor{L<:ModelType,T} <: MMI.Deterministic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::Int
+    nbins::UInt8
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -101,7 +110,7 @@ function EvoTreeRegressor(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        args[:nbins],
+        convert_parameter(UInt8, args[:nbins], :nbins),
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],
@@ -121,7 +130,7 @@ mutable struct EvoTreeCount{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::Int
+    nbins::UInt8
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -166,7 +175,7 @@ function EvoTreeCount(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        args[:nbins],
+        convert_parameter(UInt8, args[:nbins], :nbins),
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],
@@ -185,7 +194,7 @@ mutable struct EvoTreeClassifier{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::Int
+    nbins::UInt8
     alpha::T
     rng::Any
     device::Any
@@ -228,7 +237,7 @@ function EvoTreeClassifier(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        args[:nbins],
+        convert_parameter(UInt8, args[:nbins], :nbins),
         T(args[:alpha]),
         args[:rng],
         args[:device],
@@ -246,7 +255,7 @@ mutable struct EvoTreeMLE{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::Int
+    nbins::UInt8
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -302,7 +311,7 @@ function EvoTreeMLE(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        args[:nbins],
+        convert_parameter(UInt8, args[:nbins], :nbins),
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],
@@ -322,7 +331,7 @@ mutable struct EvoTreeGaussian{L<:ModelType,T} <: MMI.Probabilistic
     min_weight::T # real minimum number of observations, different from xgboost (but same for linear)
     rowsample::T # subsample
     colsample::T
-    nbins::Int
+    nbins::UInt8
     alpha::T
     monotone_constraints::Any
     rng::Any
@@ -366,7 +375,7 @@ function EvoTreeGaussian(; kwargs...)
         T(args[:min_weight]),
         T(args[:rowsample]),
         T(args[:colsample]),
-        args[:nbins],
+        convert_parameter(UInt8, args[:nbins], :nbins),
         T(args[:alpha]),
         args[:monotone_constraints],
         args[:rng],

--- a/test/core.jl
+++ b/test/core.jl
@@ -452,9 +452,9 @@ end
     @testset "check_parameter" begin
         # Valid case tests
         @test check_parameter(Float64, 1.5, 0.0, typemax(Float64), :lambda) == nothing
-        @test check_parameter(Int, 5, 0, typemax(Int), :nrounds) == nothing
-        @test check_parameter(Int, 0, 0, typemax(Int), :nrounds) == nothing
-        @test check_parameter(Int, 0, 0, 0, :nrounds) == nothing
+        @test check_parameter(Int, 5, 1, typemax(Int), :nrounds) == nothing
+        @test check_parameter(Int, 1, 1, typemax(Int), :nrounds) == nothing
+        @test check_parameter(Int, 1, 1, 1, :nrounds) == nothing
 
         # Invalid type tests
         @test_throws ErrorException check_parameter(Int, 1.5, 0, typemax(Int), :nrounds)
@@ -471,7 +471,7 @@ end
     @testset "check_args all for EvoTreeRegressor" begin
         for (key,vals_to_test) in zip(
             [:nrounds, :max_depth, :nbins, :lambda, :gamma, :min_weight, :alpha, :rowsample, :colsample, :eta],
-            [[-1, 1.5], [0, 1.5], [1, 256, 100.5], [-eps(Float64)], [-eps(Float64)], [-eps(Float64)], 
+            [[-1, 0, 1.5], [0, 1.5], [1, 256, 100.5], [-eps(Float64)], [-eps(Float64)], [-eps(Float64)], 
             [-0.1, 1.1], [0.0f0, 1.1f0], [0.0, 1.1], [0.0]]) 
             for val in vals_to_test
                 @test_throws Exception EvoTreeRegressor(;zip([key], [val])...)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,6 +1,7 @@
 using Statistics
 using StatsBase: sample
 using EvoTrees: sigmoid, logit
+using EvoTrees: check_args, check_parameter
 using Random: seed!
 
 # prepare a dataset
@@ -443,4 +444,51 @@ end
         @test config isa EvoParamType
         @test config.max_depth == 2
     end
+end
+
+
+@testset "check_args functionality" begin
+    # check_args should throw an exception if the parameters are invalid
+    @testset "check_parameter" begin
+        # Valid case tests
+        @test check_parameter(Float64, 1.5, 0.0, typemax(Float64), :lambda) == nothing
+        @test check_parameter(Int, 5, 0, typemax(Int), :nrounds) == nothing
+        @test check_parameter(Int, 0, 0, typemax(Int), :nrounds) == nothing
+        @test check_parameter(Int, 0, 0, 0, :nrounds) == nothing
+
+        # Invalid type tests
+        @test_throws ErrorException check_parameter(Int, 1.5, 0, typemax(Int), :nrounds)
+        @test_throws ErrorException check_parameter(Float64, "1.5", 0.0, typemax(Float64), :lambda)
+
+        # Out of range tests
+        @test_throws ErrorException check_parameter(Int, -5, 0, typemax(Int), :nrounds)
+        @test_throws ErrorException check_parameter(Float64, -0.1, 0.0, typemax(Float64), :lambda)
+        @test_throws ErrorException check_parameter(Int, typemax(Int64), 0, typemax(Int)-1, :nrounds)
+        @test_throws ErrorException check_parameter(Float64, typemax(Float64), 0.0, 10^6, :lambda)        
+    end
+
+    # Check the implemented parameters on construction
+    @testset "check_args all for EvoTreeRegressor" begin
+        for (key,vals_to_test) in zip(
+            [:nrounds, :max_depth, :nbins, :lambda, :gamma, :min_weight, :alpha, :rowsample, :colsample, :eta],
+            [[-1, 1.5], [0, 1.5], [1, 256, 100.5], [-eps(Float64)], [-eps(Float64)], [-eps(Float64)], 
+            [-0.1, 1.1], [0.0f0, 1.1f0], [0.0, 1.1], [0.0]]) 
+            for val in vals_to_test
+                @test_throws Exception EvoTreeRegressor(;zip([key], [val])...)
+            end
+        end
+    end
+
+    # Test all EvoTypes that they have *some* checks in place
+    @testset "check_args EvoTypes" begin
+        for EvoTreeType in [EvoTreeMLE, EvoTreeGaussian, EvoTreeCount, EvoTreeClassifier, EvoTreeRegressor]
+            config = EvoTreeType(nbins=32)
+            # should not throw an exception
+            @test check_args(config) == nothing 
+            # invalid nbins
+            config.nbins=256
+            @test_throws Exception check_args(config)
+        end
+    end
+
 end


### PR DESCRIPTION
Fixes https://github.com/Evovest/EvoTrees.jl/issues/222

An initial proposal to validate whether this design is acceptable.
- Restricts the following parameters: `nbins` (to UInt8)
- Adds a function to convert safely (`convert_parameter`) with an understandable error for the user (see example below)

MWE:
```
config = EvoTreeClassifier(nbins=255)
# works fine

config = EvoTreeClassifier(nbins=256)
# ERROR: Invalid value for parameter `nbins`: 256. `nbins` must be of type UInt8 (ie, value between 0 and 255).
```

Question:
- Are there more parameters that should be more restrictive? So far I've restricted only `nbins` to UInt8

TODO:
- corresponding tests once we agree on the approach