### PR TITLE
adhere to MLJ interface

### DIFF
--- a/src/importance.jl
+++ b/src/importance.jl
@@ -20,7 +20,7 @@ function importance(model::EvoTree; fnames=model.info[:fnames])
     end
 
     gain .= gain ./ sum(gain)
-    pairs = collect(Dict(zip(string.(fnames), gain)))
+    pairs = collect(Dict(zip(Symbol.(fnames), gain)))
     sort!(pairs, by=x -> -x[2])
 
     return pairs


### PR DESCRIPTION
MLJ interface just like Tables.jl interface assumes that features names are Symbols rather than strings. This PR corrects that as we had an issue opened by a user at https://github.com/JuliaAI/MLJ.jl/issues/1145.
cc. @ablaom 
