### PR TITLE
patch for #322 - error if cat levels > nbins

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EvoTrees"
 uuid = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
 authors = ["jeremiedb <jeremie.db@evovest.com>"]
-version = "0.18.4"
+version = "0.18.5"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/experiments/issue-322/cat-levels.jl
+++ b/experiments/issue-322/cat-levels.jl
@@ -1,0 +1,24 @@
+using CategoricalArrays
+using DataFrames
+using EvoTrees
+
+nobs = 10_000
+nfeats = 3
+nlevels = 16
+nbins = 16
+
+df = DataFrame(rand(nobs, nfeats), :auto)
+df.cat = rand(1:nlevels, nobs) |> categorical
+df.y = randn(nobs)
+length(unique(df.cat))
+target_name="y"
+feature_names = setdiff(names(df), [target_name])
+
+config = EvoTreeRegressor(; nbins)
+
+EvoTrees.fit(
+    config,
+    df;
+    target_name,
+    feature_names,
+)

--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -41,7 +41,8 @@ function get_edges(df; feature_names, nbins, rng=Random.MersenneTwister(), kwarg
             edges[j] = levels(col)
             featbins[j] = length(edges[j])
             feattypes[j] = isordered(col) ? true : false
-            @assert featbins[j] <= 255 "Max categorical levels currently limited to 255, $(feature_names[j]) has $(featbins[j])."
+            featbins[j] <= nbins || error("
+            Max categorical levels is limited to `nbins` ($nbins). Feature $(feature_names[j]) has $(featbins[j]) levels. Consider using larger `nbins`, up to 255.")
         elseif eltype(col) <: Real
             edges[j] = unique(quantile(col, (1:nbins-1) / nbins))
             featbins[j] = length(edges[j]) + 1


### PR DESCRIPTION
Fix for #322. 
Would ideally support a up to 255 levels independently of nbins and without unnecessary memory usage. 
However, this appears like a non-trivial design constraint for GPU compatiblity that operates on dense 4D histogram. 
Acting on distinct per-feature matrix proved ineffective in the past; but could be fixed if kernel could be lunched on such structure, like component arrays. 