### PR TITLE
added multiquantile loss

### DIFF
--- a/experiments/multiquantile-demo.jl
+++ b/experiments/multiquantile-demo.jl
@@ -1,0 +1,67 @@
+using Random
+using Statistics
+using EvoTrees
+
+Random.seed!(123)
+
+n = 2000
+x = rand(n)
+sigma = 0.1 .+ 0.5 .* x
+y = sin.(2pi .* x) .+ sigma .* randn(n)
+X = reshape(x, :, 1)
+
+idx = randperm(n)
+n_train = Int(round(0.8 * n))
+train_idx = idx[1:n_train]
+eval_idx = idx[n_train+1:end]
+
+x_train, x_eval = X[train_idx, :], X[eval_idx, :]
+y_train, y_eval = y[train_idx], y[eval_idx]
+
+alphas = [0.2, 0.5, 0.9]
+config = EvoTreeRegressor(
+    loss=:multiquantile,
+    alphas=alphas,
+    nrounds=100,
+    nbins=64,
+    lambda=0.0,
+    gamma=0.0,
+    eta=0.1,
+    max_depth=6,
+    min_weight=1.0,
+    rowsample=0.8,
+    colsample=1.0,
+    seed=123,
+    device=:cpu,
+)
+
+model = EvoTrees.fit(
+    config;
+    x_train,
+    y_train,
+    x_eval=x_eval,
+    y_eval=y_eval,
+    print_every_n=50,
+)
+
+preds = EvoTrees.predict(model, x_eval)
+coverage = [mean(y_eval .<= preds[:, k]) for k in eachindex(alphas)]
+println("alphas = ", alphas)
+println("coverage= ", round.(coverage; digits=3))
+
+K = length(alphas)
+crossings = [mean(preds[:, k] .> preds[:, k + 1]) for k in 1:K-1]
+any_cross = mean(vec(any(diff(preds, dims=2) .< 0, dims=2)))
+println("crossing rates (q_k > q_{k+1}) = ", round.(crossings; digits=4))
+println("any crossing rate = ", round(any_cross; digits=4))
+
+calib = hcat(alphas, coverage, coverage .- alphas)
+show(stdout, "text/plain", calib)
+println()
+
+order = sortperm(vec(x_eval))
+x_sorted = vec(x_eval)[order]
+preds_sorted = preds[order, :]
+preview = hcat(x_sorted[1:10], preds_sorted[1:10, :])
+show(stdout, "text/plain", preview)
+println()

--- a/ext/EvoTreesCUDAExt/fit-utils.jl
+++ b/ext/EvoTreesCUDAExt/fit-utils.jl
@@ -332,7 +332,7 @@ end
 end
 
 # Parent gain: Quantile
-@inline function parent_gain(::Type{EvoTrees.Quantile}, nodes_sum, node, K, λw, L2, w_p, ε::T) where {T}
+@inline function parent_gain(::Type{<:EvoTrees.Quantile}, nodes_sum, node, K, λw, L2, w_p, ε::T) where {T}
     return zero(T)
 end
 
@@ -377,7 +377,7 @@ end
 end
 
 # Split gain: Quantile
-@inline function split_gain(::Type{EvoTrees.Quantile}, s::SplitStats{T}, gain_p, lambda, L2, ε) where {T}
+@inline function split_gain(::Type{<:EvoTrees.Quantile}, s::SplitStats{T}, gain_p, lambda, L2, ε) where {T}
     μp = s.g_p / s.w_p
     μl = s.g_l / s.w_l
     μr = s.g_r / s.w_r
@@ -422,6 +422,23 @@ end
 end
 
 @inline function split_gain_multi(
+    ::Type{EvoTrees.MultiQuantile}, sums_temp, nodes_sum, node, temp_idx,
+    K, w_l, w_r, gain_p, lambda, L2, ε::T
+) where {T}
+    w_p = nodes_sum[2 * K + 1, node]
+    d_l = max(1 + lambda + L2 / w_l, ε)
+    d_r = max(1 + lambda + L2 / w_r, ε)
+    gain = zero(T)
+    for k in 1:K
+        g_l = sums_temp[k, temp_idx]
+        g_r = nodes_sum[k, node] - g_l
+        gain += abs(g_l / w_l - nodes_sum[k, node] / w_p) * w_l / d_l
+        gain += abs(g_r / w_r - nodes_sum[k, node] / w_p) * w_r / d_r
+    end
+    return gain - gain_p
+end
+
+@inline function split_gain_multi(
     ::Type{L}, sums_temp, nodes_sum, node, temp_idx,
     K, w_l, w_r, gain_p, lambda, L2, ε::T
 ) where {T,L}
@@ -455,7 +472,7 @@ end
 @inline check_monotone(::Type{EvoTrees.MAE}, constraint, args...) = false
 
 # Monotone constraint check: Quantile (no constraints)
-@inline check_monotone(::Type{EvoTrees.Quantile}, constraint, args...) = false
+@inline check_monotone(::Type{<:EvoTrees.Quantile}, constraint, args...) = false
 
 # Monotone constraint check: Cred (no constraints)
 @inline check_monotone(::Type{L}, constraint, args...) where {L<:EvoTrees.Cred} = false

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -49,6 +49,11 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         y = T.(y_train)
         μ = [EvoTrees.mean(y), log(EvoTrees.std(y) * sqrt(3) / π)]
         !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+    elseif L == EvoTrees.MultiQuantile
+        @assert eltype(y_train) <: Real
+        K = length(params.alphas)
+        y = T.(y_train)
+        μ = T.(EvoTrees.quantile.(Ref(y), params.alphas))
     else
         @assert eltype(y_train) <: Real
         K = 1

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -104,6 +104,48 @@ function EvoTrees.update_grads!(
 end
 
 #####################
+# MultiQuantile
+#####################
+function kernel_multiquantile_∇!(
+    ∇::CuDeviceMatrix{T},
+    p::CuDeviceMatrix{T},
+    y::CuDeviceVector{T},
+    alphas::CuDeviceVector{T},
+    K::Int,
+) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= length(y)
+        yi = y[i]
+        w_idx = 2 * K + 1
+        @inbounds wi = ∇[w_idx, i]
+        @inbounds for k in 1:K
+            diff = yi - p[k, i]
+            alpha = alphas[k]
+            ∇[k, i] = diff > 0 ? alpha * wi : (alpha - 1) * wi
+            ∇[K + k, i] = diff
+        end
+    end
+    return
+end
+
+function EvoTrees.update_grads!(
+    ∇::CuMatrix{T},
+    p::CuMatrix{T},
+    y::CuVector{T},
+    ::Type{EvoTrees.MultiQuantile},
+    params::EvoTrees.EvoTypes;
+    MAX_THREADS=1024,
+) where {T<:AbstractFloat}
+    K = length(params.alphas)
+    alphas = CuArray(T.(params.alphas))
+    threads = min(MAX_THREADS, length(y))
+    blocks = cld(length(y), threads)
+    @cuda blocks = blocks threads = threads kernel_multiquantile_∇!(∇, p, y, alphas, K)
+    CUDA.synchronize()
+    return
+end
+
+#####################
 # Logistic
 #####################
 function kernel_logloss_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)

--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -62,6 +62,49 @@ function EvoTrees.wmae(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuV
 end
 
 ########################
+# MultiQuantile
+########################
+function eval_multiquantile_kernel!(
+    eval::CuDeviceVector{T},
+    p::CuDeviceMatrix{T},
+    y::CuDeviceVector{T},
+    w::CuDeviceVector{T},
+    alphas::CuDeviceVector{T},
+    K::Int,
+) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= length(y)
+        yi = y[i]
+        acc = zero(T)
+        @inbounds for k in 1:K
+            diff = yi - p[k, i]
+            alpha = alphas[k]
+            acc += alpha * max(diff, zero(T)) + (1 - alpha) * max(-diff, zero(T))
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+
+function EvoTrees.multiquantile(
+    p::CuMatrix{T},
+    y::CuVector{T},
+    w::CuVector{T},
+    eval::CuVector{T};
+    MAX_THREADS=1024,
+    alphas,
+    kwargs...
+) where {T<:AbstractFloat}
+    K = length(alphas)
+    alphas_dev = alphas isa CuVector ? alphas : CuArray(T.(alphas))
+    threads = min(MAX_THREADS, length(y))
+    blocks = cld(length(y), threads)
+    @cuda blocks = blocks threads = threads eval_multiquantile_kernel!(eval, p, y, w, alphas_dev, K)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+########################
 # Logloss
 ########################
 function eval_logloss_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -1,4 +1,4 @@
-struct CallBack{B,P,Y,C,D}
+struct CallBack{B,P,Y,C,D,A}
     feval::Function
     x_bin::B
     p::P
@@ -6,6 +6,7 @@ struct CallBack{B,P,Y,C,D}
     w::C
     eval::C
     feattypes::D
+    alphas::A
 end
 
 function CallBack(
@@ -22,7 +23,6 @@ function CallBack(
     _offset_name = isnothing(offset_name) ? Symbol("") : Symbol(offset_name)
     _target_name = Symbol(target_name)
 
-    feval = metric_dict[params.metric]
     x_bin = binarize(deval; feature_names=m.info[:feature_names], edges=m.info[:edges])
     nobs = length(Tables.getcolumn(deval, 1))
     p = zeros(T, K, nobs)
@@ -43,8 +43,11 @@ function CallBack(
     else
         y = T.(y_eval)
     end
+    feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, length(y)) : V{T}(Tables.getcolumn(deval, _weight_name))
+    alphas_eval = hasproperty(params, :alphas) ? T.(params.alphas) : nothing
+    device <: GPU && !isnothing(alphas_eval) && (alphas_eval = V{T}(alphas_eval))
 
     offset = !isnothing(offset_name) ? T.(Tables.getcolumn(deval, _offset_name)) : nothing
     if !isnothing(offset)
@@ -56,7 +59,7 @@ function CallBack(
         p .+= offset'
     end
 
-    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]))
+    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), alphas_eval)
 end
 
 function CallBack(
@@ -69,7 +72,6 @@ function CallBack(
     offset_eval=nothing) where {L,K}
 
     T = Float32
-    feval = metric_dict[params.metric]
     x_bin = binarize(x_eval; feature_names=m.info[:feature_names], edges=m.info[:edges])
     p = zeros(T, K, size(x_eval, 1))
 
@@ -87,8 +89,11 @@ function CallBack(
     else
         y = T.(y_eval)
     end
+    feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(w_eval) ? device_ones(device, T, length(y)) : V{T}(w_eval)
+    alphas_eval = hasproperty(params, :alphas) ? T.(params.alphas) : nothing
+    device <: GPU && !isnothing(alphas_eval) && (alphas_eval = V{T}(alphas_eval))
 
     offset = !isnothing(offset_eval) ? T.(offset_eval) : nothing
     if !isnothing(offset)
@@ -100,12 +105,12 @@ function CallBack(
         p .+= offset'
     end
 
-    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]))
+    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), alphas_eval)
 end
 
 function (cb::CallBack)(logger, iter, tree)
     predict!(cb.p, tree, cb.x_bin, cb.feattypes)
-    metric = cb.feval(cb.p, cb.y, cb.w, cb.eval)
+    metric = cb.feval(cb.p, cb.y, cb.w, cb.eval; alphas=cb.alphas)
     update_logger!(logger, iter, metric)
     return nothing
 end

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -1,4 +1,4 @@
-struct CallBack{B,P,Y,C,D,A}
+struct CallBack{B,P,Y,C,D,K}
     feval::Function
     x_bin::B
     p::P
@@ -6,7 +6,7 @@ struct CallBack{B,P,Y,C,D,A}
     w::C
     eval::C
     feattypes::D
-    alphas::A
+    metric_kwargs::K
 end
 
 function CallBack(
@@ -46,8 +46,12 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, length(y)) : V{T}(Tables.getcolumn(deval, _weight_name))
-    alphas_eval = hasproperty(params, :alphas) ? T.(params.alphas) : nothing
-    device <: GPU && !isnothing(alphas_eval) && (alphas_eval = V{T}(alphas_eval))
+    metric_kwargs = (;)
+    if params.metric == :multiquantile
+        alphas_eval = T.(params.alphas)
+        device <: GPU && (alphas_eval = V{T}(alphas_eval))
+        metric_kwargs = (alphas=alphas_eval,)
+    end
 
     offset = !isnothing(offset_name) ? T.(Tables.getcolumn(deval, _offset_name)) : nothing
     if !isnothing(offset)
@@ -59,7 +63,7 @@ function CallBack(
         p .+= offset'
     end
 
-    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), alphas_eval)
+    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), metric_kwargs)
 end
 
 function CallBack(
@@ -92,8 +96,12 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(w_eval) ? device_ones(device, T, length(y)) : V{T}(w_eval)
-    alphas_eval = hasproperty(params, :alphas) ? T.(params.alphas) : nothing
-    device <: GPU && !isnothing(alphas_eval) && (alphas_eval = V{T}(alphas_eval))
+    metric_kwargs = (;)
+    if params.metric == :multiquantile
+        alphas_eval = T.(params.alphas)
+        device <: GPU && (alphas_eval = V{T}(alphas_eval))
+        metric_kwargs = (alphas=alphas_eval,)
+    end
 
     offset = !isnothing(offset_eval) ? T.(offset_eval) : nothing
     if !isnothing(offset)
@@ -105,12 +113,12 @@ function CallBack(
         p .+= offset'
     end
 
-    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), alphas_eval)
+    return CallBack(feval, convert(V, x_bin), convert(V, p), convert(V, y), w, similar(w), convert(V, m.info[:feattypes]), metric_kwargs)
 end
 
 function (cb::CallBack)(logger, iter, tree)
     predict!(cb.p, tree, cb.x_bin, cb.feattypes)
-    metric = cb.feval(cb.p, cb.y, cb.w, cb.eval; alphas=cb.alphas)
+    metric = cb.feval(cb.p, cb.y, cb.w, cb.eval; cb.metric_kwargs...)
     update_logger!(logger, iter, metric)
     return nothing
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -52,6 +52,11 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         y = T.(y_train)
         μ = [mean(y), log(std(y) * sqrt(3) / π)]
         !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+    elseif L == MultiQuantile
+        @assert eltype(y_train) <: Real
+        K = length(params.alphas)
+        y = T.(y_train)
+        μ = T.(quantile.(Ref(y), params.alphas))
     else
         @assert eltype(y_train) <: Real
         K = 1

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -14,6 +14,7 @@ mutable struct EvoTreeRegressor <: MMI.Deterministic
     colsample::Float64
     nbins::Int
     alpha::Float64
+    alphas::Vector{Float64}
     monotone_constraints::Dict{Int,Int}
     tree_type::Symbol
     seed::Int
@@ -39,6 +40,7 @@ function EvoTreeRegressor(; kwargs...)
         :colsample => 1.0,
         :nbins => 64,
         :alpha => 0.5,
+        :alphas => [0.1, 0.5, 0.9],
         :monotone_constraints => Dict{Int,Int}(),
         :tree_type => :binary,
         :seed => 123,
@@ -54,7 +56,7 @@ function EvoTreeRegressor(; kwargs...)
         args[arg] = kwargs[arg]
     end
 
-    _loss_list = [:mse, :logloss, :poisson, :gamma, :tweedie, :mae, :quantile, :cred_std, :cred_var]
+    _loss_list = [:mse, :logloss, :poisson, :gamma, :tweedie, :mae, :quantile, :multiquantile, :cred_std, :cred_var]
     loss = Symbol(args[:loss])
     if loss == :linear
         loss = :mse
@@ -68,7 +70,7 @@ function EvoTreeRegressor(; kwargs...)
         error("Invalid loss. Must be one of: $_loss_list")
     end
 
-    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :gini]
+    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :multiquantile, :gini]
     if isnothing(args[:metric])
         if loss ∈ [:cred_std, :cred_var]
             metric = :mae
@@ -85,6 +87,7 @@ function EvoTreeRegressor(; kwargs...)
     tree_type = Symbol(args[:tree_type])
     device = Symbol(args[:device])
     check_args(args)
+    alphas = Float64.(args[:alphas])
 
     model = EvoTreeRegressor(
         loss,
@@ -102,6 +105,7 @@ function EvoTreeRegressor(; kwargs...)
         args[:colsample],
         args[:nbins],
         args[:alpha],
+        alphas,
         args[:monotone_constraints],
         tree_type,
         args[:seed],
@@ -476,6 +480,21 @@ function check_parameter(::Type{<:T}, value, min_value::Real, max_value::Real, l
     end
 end
 
+function check_alphas(alphas)
+    try
+        @assert length(alphas) >= 2
+        prev = -Inf
+        for alpha in alphas
+            a = Float64(alpha)
+            @assert 0.0 < a < 1.0
+            @assert a > prev
+            prev = a
+        end
+    catch
+        error("Invalid value for parameter `alphas`: $alphas. `alphas` must be a strictly increasing vector with values in (0, 1).")
+    end
+end
+
 """
     check_args(args::Dict{Symbol,Any})
 
@@ -498,6 +517,10 @@ function check_args(args::Dict{Symbol,Any})
     check_parameter(Float64, args[:colsample], eps(Float64), one(Float64), :colsample)
     check_parameter(Float64, args[:eta], zero(Float64), typemax(Float64), :eta)
     haskey(args, :alpha) && check_parameter(Float64, args[:alpha], zero(Float64), one(Float64), :alpha)
+    if get(args, :loss, nothing) == :multiquantile
+        haskey(args, :alphas) || error("Missing parameter `alphas` for loss :multiquantile.")
+        check_alphas(args[:alphas])
+    end
 
     try
         tree_type = string(args[:tree_type])
@@ -531,6 +554,10 @@ function check_args(model::EvoTypes)
     check_parameter(Float64, model.colsample, eps(Float64), one(Float64), :colsample)
     check_parameter(Float64, model.eta, zero(Float64), typemax(Float64), :eta)
     hasproperty(model, :alpha) && check_parameter(Float64, model.alpha, zero(Float64), one(Float64), :alpha)
+    if hasproperty(model, :loss) && model.loss == :multiquantile
+        hasproperty(model, :alphas) || error("Missing parameter `alphas` for loss :multiquantile.")
+        check_alphas(model.alphas)
+    end
 
     try
         tree_type = string(model.tree_type)

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -482,16 +482,14 @@ end
 
 function check_alphas(alphas)
     try
-        @assert length(alphas) >= 2
-        prev = -Inf
-        for alpha in alphas
-            a = Float64(alpha)
-            @assert 0.0 < a < 1.0
-            @assert a > prev
-            prev = a
-        end
+        alphas_f = Float64.(alphas)
+        @assert !isempty(alphas_f)
+        @assert issorted(alphas_f)
+        amin, amax = extrema(alphas_f)
+        @assert 0.0 < amin && amax < 1.0
+        @assert length(unique(alphas_f)) == length(alphas_f)
     catch
-        error("Invalid value for parameter `alphas`: $alphas. `alphas` must be a strictly increasing vector with values in (0, 1).")
+        error("Invalid value for parameter `alphas`: $alphas. `alphas` must be a non-empty, strictly increasing vector with values in (0, 1).")
     end
 end
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -11,6 +11,7 @@ abstract type MLogLoss <: LossType end
 abstract type GaussianMLE <: MLE2P end
 abstract type LogisticMLE <: MLE2P end
 abstract type Quantile <: LossType end
+abstract type MultiQuantile <: Quantile end
 abstract type MAE <: LossType end
 abstract type Cred <: LossType end
 abstract type CredVar <: Cred end
@@ -26,6 +27,7 @@ const _loss2type_dict = Dict(
     :gaussian_mle => GaussianMLE,
     :logistic_mle => LogisticMLE,
     :quantile => Quantile,
+    :multiquantile => MultiQuantile,
     :mae => MAE,
     :cred_var => CredVar,
     :cred_std => CredStd
@@ -110,6 +112,22 @@ function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{Quanti
         diff = (y[i] - p[1, i])
         @inbounds ∇[1, i] = diff > 0 ? params.alpha * ∇[3, i] : (params.alpha - 1) * ∇[3, i]
         @inbounds ∇[2, i] = diff
+    end
+end
+
+# MultiQuantile
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{MultiQuantile}, params::EvoTypes,) where {T}
+    K = length(params.alphas)
+    w_idx = 2 * K + 1
+    @threads for i in eachindex(y)
+        yi = y[i]
+        @inbounds wi = ∇[w_idx, i]
+        @inbounds for k in 1:K
+            diff = yi - p[k, i]
+            alpha = params.alphas[k]
+            ∇[k, i] = diff > 0 ? alpha * wi : (alpha - 1) * wi
+            ∇[K + k, i] = diff
+        end
     end
 end
 
@@ -231,6 +249,23 @@ function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V)
     ϵ = eps(T)
     gain = abs(∑L[1] / ∑L[3] - ∑[1] / ∑[3]) * ∑L[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑L[3])) +
            abs(∑R[1] / ∑R[3] - ∑[1] / ∑[3]) * ∑R[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑R[3]))
+    return gain
+end
+
+# MultiQuantile
+function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V) where {L<:MultiQuantile,T,V<:AbstractVector}
+    ϵ = eps(T)
+    K = (length(∑) - 1) ÷ 2
+    w_p = ∑[end]
+    w_l = ∑L[end]
+    w_r = ∑R[end]
+    d_l = max(ϵ, (1 + params.lambda + params.L2 / w_l))
+    d_r = max(ϵ, (1 + params.lambda + params.L2 / w_r))
+    gain = zero(T)
+    @inbounds for k in 1:K
+        gain += abs(∑L[k] / w_l - ∑[k] / w_p) * w_l / d_l
+        gain += abs(∑R[k] / w_r - ∑[k] / w_p) * w_r / d_r
+    end
     return gain
 end
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -151,6 +151,30 @@ function wmae(
     return sum(Float64, eval) / sum(Float64, w)
 end
 
+function multiquantile(
+    p::AbstractMatrix{T},
+    y::AbstractVector{T},
+    w::AbstractVector{T},
+    eval::AbstractVector{T};
+    alphas,
+    kwargs...
+) where {T}
+    K = length(alphas)
+    @assert size(p, 1) == K
+    @threads for i in eachindex(y)
+        yi = y[i]
+        wi = w[i]
+        acc = zero(T)
+        @inbounds for k in 1:K
+            diff = yi - p[k, i]
+            alpha = alphas[k]
+            acc += alpha * max(diff, zero(T)) + (1 - alpha) * max(-diff, zero(T))
+        end
+        eval[i] = wi * acc / K
+    end
+    return sum(Float64, eval) / sum(Float64, w)
+end
+
 
 function gini_raw(p::V, y::V) where {V<:AbstractVector}
     _y = y .- minimum(y)
@@ -198,6 +222,7 @@ const metric_dict = Dict(
     :logistic_mle => logistic_mle,
     :wmae => wmae,
     :quantile => wmae,
+    :multiquantile => multiquantile,
     :gini => gini,
 )
 
@@ -212,4 +237,5 @@ is_maximise(::typeof(tweedie)) = false
 is_maximise(::typeof(gaussian_mle)) = true
 is_maximise(::typeof(logistic_mle)) = true
 is_maximise(::typeof(wmae)) = false
+is_maximise(::typeof(multiquantile)) = false
 is_maximise(::typeof(gini)) = true

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -179,3 +179,12 @@ function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params:
     ϵ = eps(T)
     p[1, n] = params.eta / params.bagging_size * quantile(view(∇, 2, is), params.alpha) / (1 + params.lambda + params.L2 / ∑[3])
 end
+
+# MultiQuantile
+function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes, ∇, is) where {L<:MultiQuantile,T}
+    K = length(params.alphas)
+    denom = 1 + params.lambda + params.L2 / ∑[end]
+    @inbounds for k in 1:K
+        p[k, n] = params.eta / params.bagging_size * quantile(view(∇, K + k, is), params.alphas[k]) / denom
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -220,6 +220,41 @@ end
     @test mse_gain_pct < -0.75
 end
 
+@testset "EvoTreeRegressor - MultiQuantile" begin
+    alphas = [0.2, 0.5, 0.8]
+    params1 = EvoTreeRegressor(
+        loss=:multiquantile,
+        alphas=alphas,
+        nrounds=50,
+        nbins=16,
+        lambda=0.5,
+        gamma=0.0,
+        eta=0.1,
+        max_depth=6,
+        min_weight=1.0,
+        rowsample=0.5,
+        colsample=1.0,
+        seed=123,
+    )
+
+    model, cache = EvoTrees.init(params1, x_train, y_train)
+    preds_ini = EvoTrees.predict(model, x_eval)
+    @test size(preds_ini) == (length(y_eval), length(alphas))
+
+    model = fit(
+        params1;
+        x_train,
+        y_train,
+        x_eval,
+        y_eval,
+        print_every_n=100
+    )
+
+    preds = EvoTrees.predict(model, x_eval)
+    @test size(preds) == (length(y_eval), length(alphas))
+    @test !any(isnan.(preds))
+end
+
 @testset "EvoTreeCount - Count" begin
     params1 = EvoTreeCount(
         nrounds=100,
@@ -433,6 +468,14 @@ end
                 @test_throws Exception EvoTreeRegressor(; zip([key], [val])...)
             end
         end
+    end
+
+    @testset "check_args EvoTreeRegressor - MultiQuantile" begin
+        @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.5])
+        @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.6, 0.4])
+        @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.0, 0.5])
+        config = EvoTreeRegressor(loss=:multiquantile, alphas=[0.2, 0.5, 0.8], nrounds=1)
+        @test check_args(config) === nothing
     end
 
     # Test all EvoTypes that they have *some* checks in place

--- a/test/core.jl
+++ b/test/core.jl
@@ -471,10 +471,10 @@ end
     end
 
     @testset "check_args EvoTreeRegressor - MultiQuantile" begin
-        @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.5])
         @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.6, 0.4])
         @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.0, 0.5])
-        config = EvoTreeRegressor(loss=:multiquantile, alphas=[0.2, 0.5, 0.8], nrounds=1)
+        @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.5, 0.5])
+        config = EvoTreeRegressor(loss=:multiquantile, alphas=[0.5], nrounds=1)
         @test check_args(config) === nothing
     end
 


### PR DESCRIPTION
### Summary
Closes #269.

adds `:multiquantile` loss to `EvoTreeRegressor` for predicting K 
quantiles simultaneously in a single model.

### Changes
- New `MultiQuantile` loss type with gradient layout `[1:K]` , `[K+1:2K]` residuals, `[2K+1]` weights
- `EvoTreeRegressor` gains `alphas` parameter (default `[0.1, 0.5, 0.9]`)
- Exact residual quantiles for leaf values (same approach as single quantiel)
- MAE-style split gain summed across K outputs
- Empirical quantile bias initialization per alpha
- CPU + GPU support
- Tests and demo script

### Testing
```julia
Pkg.test("EvoTrees")
```