### PR TITLE
Add multi-target regression (:mtmse): joint vector-target fitting on CPU + GPU

### DIFF
--- a/blog/cred/utils.jl
+++ b/blog/cred/utils.jl
@@ -1,6 +1,6 @@
 ## package loading
 using EvoTrees
-using EvoTrees: _get_cred, _loss2type_dict, update_grads!, Cred, EvoTypes, GradientRegression
+using EvoTrees: _cred_Z, _loss2type_dict, update_grads!, Cred, EvoTypes, GradientRegression
 using DataFrames
 using Distributions
 using Statistics: mean, std
@@ -32,7 +32,8 @@ function get_simul_metric(metric_name="cred"; nobs, loss, spread=1.0, sd=1.0)
     ∑ = get_∑(p, y, L, config)
 
     if metric_name == "cred"
-        metric = _get_cred(L, config, ∑)
+        ϵ = eps(eltype(∑))
+        metric = _cred_Z(L, ∑[1], ∑[2], ∑[end], ϵ)
     elseif metric_name == "gain"
         metric = _get_gain(L, config, ∑)
     else
@@ -68,7 +69,8 @@ function get_data(; loss, nobs, spread=1.0, sd=1.0)
     data[:gC] = data[:gL] + data[:gR]
 
     if L <: Cred
-        data[:ZR] = _get_cred(L, config, ∑R)
+        ϵ = eps(eltype(∑R))
+        data[:ZR] = _cred_Z(L, ∑R[1], ∑R[2], ∑R[end], ϵ)
     else
         data[:ZR] = NaN
     end

--- a/ext/EvoTreesCUDAExt/fit-utils.jl
+++ b/ext/EvoTreesCUDAExt/fit-utils.jl
@@ -309,11 +309,12 @@ end
 
 # Parent gain: MLE2P
 @inline function parent_gain(::Type{L}, nodes_sum, node, K, λw, L2, w_p, ε::T) where {T,L<:EvoTrees.MLE2P}
-    g1, g2 = nodes_sum[1, node], nodes_sum[2, node]
-    h1, h2 = nodes_sum[3, node], nodes_sum[4, node]
-    d1 = max(h1 + λw + L2, ε)
-    d2 = max(h2 + λw + L2, ε)
-    return (g1^2 / d1 + g2^2 / d2) / 2
+    gain = zero(T)
+    for k in 1:K
+        g, h = nodes_sum[k, node], nodes_sum[K+k, node]
+        gain += g^2 / max(h + λw + L2, ε)
+    end
+    return gain / 2
 end
 
 # Parent gain: MLogLoss

--- a/ext/EvoTreesCUDAExt/fit-utils.jl
+++ b/ext/EvoTreesCUDAExt/fit-utils.jl
@@ -442,6 +442,23 @@ end
 @inline function split_gain_multi(
     ::Type{L}, sums_temp, nodes_sum, node, temp_idx,
     K, w_l, w_r, gain_p, lambda, L2, ε::T
+) where {T,L<:Union{EvoTrees.MAE,EvoTrees.Quantile}}
+    w_p = nodes_sum[2 * K + 1, node]
+    d_l = max(1 + lambda + L2 / w_l, ε)
+    d_r = max(1 + lambda + L2 / w_r, ε)
+    gain = zero(T)
+    for k in 1:K
+        g_l = sums_temp[k, temp_idx]
+        g_r = nodes_sum[k, node] - g_l
+        gain += abs(g_l / w_l - nodes_sum[k, node] / w_p) * w_l / d_l
+        gain += abs(g_r / w_r - nodes_sum[k, node] / w_p) * w_r / d_r
+    end
+    return gain - gain_p
+end
+
+@inline function split_gain_multi(
+    ::Type{L}, sums_temp, nodes_sum, node, temp_idx,
+    K, w_l, w_r, gain_p, lambda, L2, ε::T
 ) where {T,L}
     return T(-Inf)
 end

--- a/ext/EvoTreesCUDAExt/fit-utils.jl
+++ b/ext/EvoTreesCUDAExt/fit-utils.jl
@@ -339,11 +339,14 @@ end
 
 # Parent gain: Cred
 @inline function parent_gain(::Type{L}, nodes_sum, node, K, λw, L2, w_p, ε::T) where {T,L<:EvoTrees.Cred}
-    μ = nodes_sum[1, node] / w_p
-    VHM = μ^2
-    EVPV = max(nodes_sum[2, node] / w_p - VHM, ε)
-    Z = VHM / (VHM + EVPV)
-    return Z * abs(nodes_sum[1, node]) / (1 + L2 / w_p)
+    gain = zero(T)
+    for k in 1:K
+        m1 = nodes_sum[k, node]
+        m2 = nodes_sum[K+k, node]
+        Z = EvoTrees._cred_Z(L, m1, m2, w_p, ε)
+        gain += Z * abs(m1) / (1 + L2 / w_p)
+    end
+    return gain
 end
 
 # Split gain: GradientRegression
@@ -389,18 +392,10 @@ end
 
 # Split gain: Cred
 @inline function split_gain(::Type{L}, s::SplitStats{T}, gain_p, lambda, L2, ε) where {T,L<:EvoTrees.Cred}
-    μl = s.g_l / s.w_l
-    VHM_l = μl^2
-    EVPV_l = max(s.h_l / s.w_l - VHM_l, ε)
-    Z_l = VHM_l / (VHM_l + EVPV_l)
+    Z_l = EvoTrees._cred_Z(L, s.g_l, s.h_l, s.w_l, ε)
     gain_l = Z_l * abs(s.g_l) / (1 + L2 / s.w_l)
-
-    μr = s.g_r / s.w_r
-    VHM_r = μr^2
-    EVPV_r = max(s.h_r / s.w_r - VHM_r, ε)
-    Z_r = VHM_r / (VHM_r + EVPV_r)
+    Z_r = EvoTrees._cred_Z(L, s.g_r, s.h_r, s.w_r, ε)
     gain_r = Z_r * abs(s.g_r) / (1 + L2 / s.w_r)
-
     return gain_l + gain_r - gain_p
 end
 
@@ -452,6 +447,24 @@ end
         g_r = nodes_sum[k, node] - g_l
         gain += abs(g_l / w_l - nodes_sum[k, node] / w_p) * w_l / d_l
         gain += abs(g_r / w_r - nodes_sum[k, node] / w_p) * w_r / d_r
+    end
+    return gain - gain_p
+end
+
+@inline function split_gain_multi(
+    ::Type{L}, sums_temp, nodes_sum, node, temp_idx,
+    K, w_l, w_r, gain_p, lambda, L2, ε::T
+) where {T,L<:EvoTrees.Cred}
+    gain = zero(T)
+    for k in 1:K
+        m1_l = sums_temp[k, temp_idx]
+        m2_l = sums_temp[K+k, temp_idx]
+        m1_r = nodes_sum[k, node] - m1_l
+        m2_r = nodes_sum[K+k, node] - m2_l
+        Z_l = EvoTrees._cred_Z(L, m1_l, m2_l, w_l, ε)
+        Z_r = EvoTrees._cred_Z(L, m1_r, m2_r, w_r, ε)
+        gain += Z_l * abs(m1_l) / (1 + L2 / w_l)
+        gain += Z_r * abs(m1_r) / (1 + L2 / w_r)
     end
     return gain - gain_p
 end

--- a/ext/EvoTreesCUDAExt/fit.jl
+++ b/ext/EvoTreesCUDAExt/fit.jl
@@ -61,7 +61,7 @@ function grow_tree!(
     ∇_gpu = cache.∇
     if L <: EvoTrees.MAE
         ∇_gpu = copy(cache.∇)
-        ∇_gpu[2, :] .= 1.0f0
+        ∇_gpu[(cache.K+1):(2*cache.K), :] .= 1.0f0
     end
 
     # Initialize cache arrays

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -17,20 +17,26 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     if L == EvoTrees.LogLoss
         @assert eltype(y_train) <: Real && minimum(y_train) >= 0 && maximum(y_train) <= 1
         if y_train isa AbstractVector
-            K = 1; y = reshape(T.(y_train), 1, :)
+            K = 1
+            y = T.(y_train)
+            μ = T[EvoTrees.logit(sum(y) / length(y))]
         else
-            K = size(y_train, 1); y = T.(y_train)
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[EvoTrees.logit(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         end
-        μ = T[EvoTrees.logit(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         !isnothing(offset) && (offset .= EvoTrees.logit.(offset))
     elseif L in [EvoTrees.Poisson, EvoTrees.Gamma, EvoTrees.Tweedie]
         @assert eltype(y_train) <: Real
         if y_train isa AbstractVector
-            K = 1; y = reshape(T.(y_train), 1, :)
+            K = 1
+            y = T.(y_train)
+            μ = T[log(sum(y) / length(y))]
         else
-            K = size(y_train, 1); y = T.(y_train)
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[log(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         end
-        μ = T[log(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == EvoTrees.MLogLoss
         if eltype(y_train) <: EvoTrees.CategoricalValue
@@ -69,11 +75,14 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         @assert eltype(y_train) <: Real
         if L <: EvoTrees.GradientRegression
             if y_train isa AbstractVector
-                K = 1; y = reshape(T.(y_train), 1, :)
+                K = 1
+                y = T.(y_train)
+                μ = T[sum(y) / length(y)]
             else
-                K = size(y_train, 1); y = T.(y_train)
+                K = size(y_train, 1)
+                y = T.(y_train)
+                μ = T[sum(view(y, k, :)) / size(y, 2) for k in 1:K]
             end
-            μ = T[sum(view(y, k, :)) / size(y, 2) for k in 1:K]
         else
             K = 1
             y = T.(y_train)

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -7,9 +7,9 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     T = Float32
     L = EvoTrees._loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: EvoTrees.GradientRegression)
+    if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P})
         error("Multi-target (vector target_name) is only supported for single-parameter " *
-              "regression losses (mse, logloss, poisson, gamma, tweedie). Got loss $(params.loss).")
+              "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
     end
 
     target_levels = nothing
@@ -56,16 +56,51 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == EvoTrees.GaussianMLE
         @assert eltype(y_train) <: Real
-        K = 2
-        y = T.(y_train)
-        μ = [EvoTrees.mean(y), log(EvoTrees.std(y))]
-        !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        if y_train isa AbstractVector
+            K = 2
+            y = T.(y_train)
+            n = length(y)
+            m = sum(y) / n
+            s = sqrt(sum((y .- m) .^ 2) / max(n - 1, 1))
+            μ = [m, log(s)]
+            !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        else
+            Y = size(y_train, 1)
+            K = 2 * Y
+            y = T.(y_train)
+            μ = T[]
+            n_y = size(y, 2)
+            for t in 1:Y
+                yt = view(y, t, :)
+                m_t = sum(yt) / n_y
+                s_t = sqrt(sum((yt .- m_t) .^ 2) / max(n_y - 1, 1))
+                push!(μ, m_t, log(s_t))
+            end
+            !isnothing(offset) && (offset[:, 2:2:end] .= log.(offset[:, 2:2:end]))
+        end
     elseif L == EvoTrees.LogisticMLE
         @assert eltype(y_train) <: Real
-        K = 2
-        y = T.(y_train)
-        μ = [EvoTrees.mean(y), log(EvoTrees.std(y) * sqrt(3) / π)]
-        !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        if y_train isa AbstractVector
+            K = 2
+            y = T.(y_train)
+            m = sum(y) / length(y)
+            s = sqrt(sum((y .- m) .^ 2) / max(length(y) - 1, 1))
+            μ = [m, log(s * sqrt(3) / π)]
+            !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        else
+            Y = size(y_train, 1)
+            K = 2 * Y
+            y = T.(y_train)
+            μ = T[]
+            n_y = size(y, 2)
+            for t in 1:Y
+                yt = view(y, t, :)
+                m_t = sum(yt) / n_y
+                s_t = sqrt(sum((yt .- m_t) .^ 2) / max(n_y - 1, 1))
+                push!(μ, m_t, log(s_t * sqrt(3) / π))
+            end
+            !isnothing(offset) && (offset[:, 2:2:end] .= log.(offset[:, 2:2:end]))
+        end
     elseif L == EvoTrees.MultiQuantile
         @assert eltype(y_train) <: Real
         K = length(params.alphas)

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -7,19 +7,30 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     T = Float32
     L = EvoTrees._loss2type_dict[params.loss]
 
+    if (y_train isa AbstractMatrix) && !(L <: EvoTrees.GradientRegression)
+        error("Multi-target (vector target_name) is only supported for single-parameter " *
+              "regression losses (mse, logloss, poisson, gamma, tweedie). Got loss $(params.loss).")
+    end
+
     target_levels = nothing
     target_isordered = false
     if L == EvoTrees.LogLoss
         @assert eltype(y_train) <: Real && minimum(y_train) >= 0 && maximum(y_train) <= 1
-        K = 1
-        y = T.(y_train)
-        μ = [EvoTrees.logit(EvoTrees.mean(y))]
+        if y_train isa AbstractVector
+            K = 1; y = reshape(T.(y_train), 1, :)
+        else
+            K = size(y_train, 1); y = T.(y_train)
+        end
+        μ = T[EvoTrees.logit(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         !isnothing(offset) && (offset .= EvoTrees.logit.(offset))
     elseif L in [EvoTrees.Poisson, EvoTrees.Gamma, EvoTrees.Tweedie]
         @assert eltype(y_train) <: Real
-        K = 1
-        y = T.(y_train)
-        μ = fill(log(EvoTrees.mean(y)), 1)
+        if y_train isa AbstractVector
+            K = 1; y = reshape(T.(y_train), 1, :)
+        else
+            K = size(y_train, 1); y = T.(y_train)
+        end
+        μ = T[log(sum(view(y, k, :)) / size(y, 2)) for k in 1:K]
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == EvoTrees.MLogLoss
         if eltype(y_train) <: EvoTrees.CategoricalValue
@@ -56,9 +67,18 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         μ = T.(EvoTrees.quantile.(Ref(y), params.alphas))
     else
         @assert eltype(y_train) <: Real
-        K = 1
-        y = T.(y_train)
-        μ = [EvoTrees.mean(y)]
+        if L <: EvoTrees.GradientRegression
+            if y_train isa AbstractVector
+                K = 1; y = reshape(T.(y_train), 1, :)
+            else
+                K = size(y_train, 1); y = T.(y_train)
+            end
+            μ = T[sum(view(y, k, :)) / size(y, 2) for k in 1:K]
+        else
+            K = 1
+            y = T.(y_train)
+            μ = [sum(y) / length(y)]
+        end
     end
     y = CuArray(y)
     μ = T.(μ)
@@ -73,7 +93,7 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     h∇ = KernelAbstractions.zeros(backend, Float64, 2 * K + 1, maximum(featbins), length(featbins), 2^params.max_depth - 1)
     h∇L = KernelAbstractions.zeros(backend, Float64, 2 * K + 1, maximum(featbins), length(featbins), 2^params.max_depth - 1)
     h∇R = KernelAbstractions.zeros(backend, Float64, 2 * K + 1, maximum(featbins), length(featbins), 2^params.max_depth - 1)
-    @assert (length(y) == length(w) && minimum(w) > 0)
+    @assert (size(y, ndims(y)) == length(w) && minimum(w) > 0)
     ∇[end, :] .= w
 
     nidx = KernelAbstractions.ones(backend, UInt32, nobs)

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -8,9 +8,10 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     L = EvoTrees._loss2type_dict[params.loss]
 
     if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P, EvoTrees.MAE, EvoTrees.Quantile, EvoTrees.Cred})
-        error("Multi-target (vector target_name) is only supported for single-parameter " *
-              "regression losses, MLE losses (gaussian_mle, logistic_mle), MAE, quantile, " *
-              "and credibility losses (cred_var, cred_std). Got loss $(params.loss).")
+        error("Multi-target (matrix target) is supported for gradient-regression losses " *
+              "(mse, logloss, poisson, gamma, tweedie), mae, quantile, the MLE losses " *
+              "(gaussian_mle, logistic_mle), and credibility losses (cred_var, cred_std). " *
+              "Got loss $(params.loss).")
     end
 
     target_levels = nothing

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -7,9 +7,10 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     T = Float32
     L = EvoTrees._loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P, EvoTrees.MAE, EvoTrees.Quantile})
+    if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P, EvoTrees.MAE, EvoTrees.Quantile, EvoTrees.Cred})
         error("Multi-target (vector target_name) is only supported for single-parameter " *
-              "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
+              "regression losses, MLE losses (gaussian_mle, logistic_mle), MAE, quantile, " *
+              "and credibility losses (cred_var, cred_std). Got loss $(params.loss).")
     end
 
     target_levels = nothing
@@ -107,6 +108,17 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         y = T.(y_train)
         μ = T.(EvoTrees.quantile.(Ref(y), params.alphas))
     elseif L <: Union{EvoTrees.MAE,EvoTrees.Quantile}
+        @assert eltype(y_train) <: Real
+        if y_train isa AbstractVector
+            K = 1
+            y = T.(y_train)
+            μ = T[sum(y) / length(y)]
+        else
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[sum(view(y, k, :)) / size(y, 2) for k in 1:K]
+        end
+    elseif L <: EvoTrees.Cred
         @assert eltype(y_train) <: Real
         if y_train isa AbstractVector
             K = 1

--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -7,7 +7,7 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
     T = Float32
     L = EvoTrees._loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P})
+    if (y_train isa AbstractMatrix) && !(L <: Union{EvoTrees.GradientRegression, EvoTrees.MLE2P, EvoTrees.MAE, EvoTrees.Quantile})
         error("Multi-target (vector target_name) is only supported for single-parameter " *
               "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
     end
@@ -106,6 +106,17 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
         K = length(params.alphas)
         y = T.(y_train)
         μ = T.(EvoTrees.quantile.(Ref(y), params.alphas))
+    elseif L <: Union{EvoTrees.MAE,EvoTrees.Quantile}
+        @assert eltype(y_train) <: Real
+        if y_train isa AbstractVector
+            K = 1
+            y = T.(y_train)
+            μ = T[sum(y) / length(y)]
+        else
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[sum(view(y, k, :)) / size(y, 2) for k in 1:K]
+        end
     else
         @assert eltype(y_train) <: Real
         if L <: EvoTrees.GradientRegression

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -421,23 +421,43 @@ function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{
     return
 end
 
-function kernel_gradreg_∇!(∇, p, y, ::Type{EvoTrees.MSE})
+@inline gradreg_grad_hess(::Type{EvoTrees.MSE}, pk, yk) = (2 * (pk - yk), 2 * one(pk))
+@inline function gradreg_grad_hess(::Type{EvoTrees.LogLoss}, pk, yk)
+    pred = EvoTrees.sigmoid(pk)
+    return (pred - yk, pred * (1 - pred))
+end
+@inline gradreg_grad_hess(::Type{EvoTrees.Poisson}, pk, yk) = (exp(pk) - yk, exp(pk))
+@inline function gradreg_grad_hess(::Type{EvoTrees.Gamma}, pk, yk)
+    pred = exp(pk)
+    return (2 * (1 - yk / pred), 2 * yk / pred)
+end
+@inline function gradreg_grad_hess(::Type{EvoTrees.Tweedie}, pk, yk)
+    rho = oftype(pk, 1.5)
+    pred = exp(pk)
+    return (
+        2 * (pred^(2 - rho) - yk * pred^(1 - rho)),
+        2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * yk * pred^(1 - rho)),
+    )
+end
+
+function kernel_gradreg_∇!(∇, p, y, ::Type{L}) where {L<:EvoTrees.GradientRegression}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     if i <= size(y, 2)
         K = size(p, 1)
         w_row = 2 * K + 1
         @inbounds w = ∇[w_row, i]
         @inbounds for k in 1:K
-            ∇[k, i]   = 2 * (p[k, i] - y[k, i]) * w
-            ∇[K+k, i] = 2 * w
+            g, h = gradreg_grad_hess(L, p[k, i], y[k, i])
+            ∇[k, i] = g * w
+            ∇[K+k, i] = h * w
         end
     end
     return
 end
-function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{EvoTrees.MSE}, params::EvoTrees.EvoTypes; MAX_THREADS=1024)
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{L}, params::EvoTrees.EvoTypes; MAX_THREADS=1024) where {L<:EvoTrees.GradientRegression}
     threads = min(MAX_THREADS, size(y, 2))
     blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, EvoTrees.MSE)
+    @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, L)
     CUDA.synchronize()
     return
 end

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -327,7 +327,7 @@ function EvoTrees.update_grads!(
     return
 end
 
-function kernel_gradreg_∇!(∇, p, y, ::Type{L}) where {L<:EvoTrees.GradientRegression}
+function kernel_gradreg_∇!(∇, p, y, ::Type{EvoTrees.MSE})
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     if i <= size(y, 2)
         K = size(p, 1)
@@ -340,10 +340,10 @@ function kernel_gradreg_∇!(∇, p, y, ::Type{L}) where {L<:EvoTrees.GradientRe
     end
     return
 end
-function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{L}, params::EvoTrees.EvoTypes; MAX_THREADS=1024) where {L<:EvoTrees.GradientRegression}
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{EvoTrees.MSE}, params::EvoTrees.EvoTypes; MAX_THREADS=1024)
     threads = min(MAX_THREADS, size(y, 2))
     blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, L)
+    @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, EvoTrees.MSE)
     CUDA.synchronize()
     return
 end

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -35,24 +35,30 @@ end
 #####################
 # Credibility
 #####################
-function kernel_cred_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
+function kernel_cred_∇!(∇::CuDeviceMatrix{T}, p::CuDeviceMatrix{T}, y) where {T}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds ∇[1, i] = (y[i] - p[1, i]) * ∇[3, i]
-        @inbounds ∇[2, i] = (y[i] - p[1, i])^2 * ∇[3, i]
+    if i <= size(p, 2)
+        K = size(p, 1)
+        w_row = 2 * K + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            d = _cuda_target(y, k, i) - p[k, i]
+            ∇[k, i] = d * w
+            ∇[K+k, i] = d^2 * w
+        end
     end
     return
 end
 function EvoTrees.update_grads!(
     ∇::CuMatrix,
     p::CuMatrix,
-    y::CuVector,
+    y::Union{CuVector,CuMatrix},
     ::Type{<:EvoTrees.Cred},
     params::EvoTrees.EvoTypes;
     MAX_THREADS=1024,
 )
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
+    threads = min(MAX_THREADS, size(p, 2))
+    blocks = cld(size(p, 2), threads)
     @cuda blocks = blocks threads = threads kernel_cred_∇!(∇, p, y)
     CUDA.synchronize()
     return

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -1,49 +1,32 @@
-#####################
-# MSE
-#####################
-function kernel_mse_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds ∇[1, i] = 2 * (p[i] - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = 2 * ∇[3, i]
-    end
-    return
-end
-function EvoTrees.update_grads!(
-    ∇::CuMatrix,
-    p::CuMatrix,
-    y::CuVector,
-    ::Type{EvoTrees.MSE},
-    params::EvoTrees.EvoTypes;
-    MAX_THREADS=1024,
-)
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads kernel_mse_∇!(∇, p, y)
-    CUDA.synchronize()
-    return
-end
+@inline _cuda_target(y::CuDeviceVector, k, i) = y[i]
+@inline _cuda_target(y::CuDeviceMatrix, k, i) = y[k, i]
 
 #####################
 # MAE
 #####################
-function kernel_mae_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
+function kernel_mae_∇!(∇::CuDeviceMatrix{T}, p::CuDeviceMatrix{T}, y) where {T}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds ∇[1, i] = (y[i] - p[1, i]) * ∇[3, i]
+    if i <= size(p, 2)
+        K = size(p, 1)
+        w_row = 2 * K + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            ∇[k, i] = (_cuda_target(y, k, i) - p[k, i]) * w
+            ∇[K+k, i] = zero(T)
+        end
     end
     return
 end
 function EvoTrees.update_grads!(
     ∇::CuMatrix,
     p::CuMatrix,
-    y::CuVector,
+    y::Union{CuVector,CuMatrix},
     ::Type{EvoTrees.MAE},
     params::EvoTrees.EvoTypes;
     MAX_THREADS=1024,
 )
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
+    threads = min(MAX_THREADS, size(p, 2))
+    blocks = cld(size(p, 2), threads)
     @cuda blocks = blocks threads = threads kernel_mae_∇!(∇, p, y)
     CUDA.synchronize()
     return
@@ -78,26 +61,30 @@ end
 #####################
 # Quantile
 #####################
-function kernel_quantile_∇!(∇::CuDeviceMatrix{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, alpha::T) where {T<:AbstractFloat}
+function kernel_quantile_∇!(∇::CuDeviceMatrix{T}, p::CuDeviceMatrix{T}, y, alpha::T) where {T<:AbstractFloat}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds ∇[1, i] = (y[i] - p[1, i]) * ∇[3, i]
-        diff = (y[i] - p[1, i])
-        @inbounds ∇[1, i] = diff > 0 ? alpha * ∇[3, i] : (alpha - 1) * ∇[3, i]
-        @inbounds ∇[2, i] = diff
+    if i <= size(p, 2)
+        K = size(p, 1)
+        w_row = 2 * K + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            diff = _cuda_target(y, k, i) - p[k, i]
+            ∇[k, i] = diff > 0 ? alpha * w : (alpha - 1) * w
+            ∇[K+k, i] = diff
+        end
     end
     return
 end
 function EvoTrees.update_grads!(
     ∇::CuMatrix{T},
     p::CuMatrix{T},
-    y::CuVector{T},
+    y::Union{CuVector{T},CuMatrix{T}},
     ::Type{EvoTrees.Quantile},
     params::EvoTrees.EvoTypes;
     MAX_THREADS=1024,
 ) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
+    threads = min(MAX_THREADS, size(p, 2))
+    blocks = cld(size(p, 2), threads)
     @cuda blocks = blocks threads = threads kernel_quantile_∇!(∇, p, y, T(params.alpha))
     CUDA.synchronize()
     return
@@ -141,116 +128,6 @@ function EvoTrees.update_grads!(
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads kernel_multiquantile_∇!(∇, p, y, alphas, K)
-    CUDA.synchronize()
-    return
-end
-
-#####################
-# Logistic
-#####################
-function kernel_logloss_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds pred = EvoTrees.sigmoid(p[1, i])
-        @inbounds ∇[1, i] = (pred - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = pred * (1 - pred) * ∇[3, i]
-    end
-    return
-end
-function EvoTrees.update_grads!(
-    ∇::CuMatrix,
-    p::CuMatrix,
-    y::CuVector,
-    ::Type{EvoTrees.LogLoss},
-    params::EvoTrees.EvoTypes;
-    MAX_THREADS=1024,
-)
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads kernel_logloss_∇!(∇, p, y)
-    CUDA.synchronize()
-    return
-end
-
-#####################
-# Poisson
-#####################
-function kernel_poisson_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds ∇[1, i] = (pred - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = pred * ∇[3, i]
-    end
-    return
-end
-function EvoTrees.update_grads!(
-    ∇::CuMatrix,
-    p::CuMatrix,
-    y::CuVector,
-    ::Type{EvoTrees.Poisson},
-    params::EvoTrees.EvoTypes;
-    MAX_THREADS=1024,
-)
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads kernel_poisson_∇!(∇, p, y)
-    CUDA.synchronize()
-    return
-end
-
-#####################
-# Gamma
-#####################
-function kernel_gamma_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        pred = exp(p[1, i])
-        @inbounds ∇[1, i] = 2 * (1 - y[i] / pred) * ∇[3, i]
-        @inbounds ∇[2, i] = 2 * y[i] / pred * ∇[3, i]
-    end
-    return
-end
-function EvoTrees.update_grads!(
-    ∇::CuMatrix,
-    p::CuMatrix,
-    y::CuVector,
-    ::Type{EvoTrees.Gamma},
-    params::EvoTrees.EvoTypes;
-    MAX_THREADS=1024,
-)
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads kernel_gamma_∇!(∇, p, y)
-    CUDA.synchronize()
-    return
-end
-
-#####################
-# Tweedie
-#####################
-function kernel_tweedie_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    rho = eltype(p)(1.5)
-    if i <= length(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds ∇[1, i] = 2 * (pred^(2 - rho) - y[i] * pred^(1 - rho)) * ∇[3, i]
-        @inbounds ∇[2, i] =
-            2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * y[i] * pred^(1 - rho)) * ∇[3, i]
-    end
-    return
-end
-function EvoTrees.update_grads!(
-    ∇::CuMatrix,
-    p::CuMatrix,
-    y::CuVector,
-    ::Type{EvoTrees.Tweedie},
-    params::EvoTrees.EvoTypes;
-    MAX_THREADS=1024,
-)
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads kernel_tweedie_∇!(∇, p, y)
     CUDA.synchronize()
     return
 end
@@ -442,21 +319,21 @@ end
 
 function kernel_gradreg_∇!(∇, p, y, ::Type{L}) where {L<:EvoTrees.GradientRegression}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
+    if i <= size(p, 2)
         K = size(p, 1)
         w_row = 2 * K + 1
         @inbounds w = ∇[w_row, i]
         @inbounds for k in 1:K
-            g, h = gradreg_grad_hess(L, p[k, i], y[k, i])
+            g, h = gradreg_grad_hess(L, p[k, i], _cuda_target(y, k, i))
             ∇[k, i] = g * w
             ∇[K+k, i] = h * w
         end
     end
     return
 end
-function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{L}, params::EvoTrees.EvoTypes; MAX_THREADS=1024) where {L<:EvoTrees.GradientRegression}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::Union{CuVector,CuMatrix}, ::Type{L}, params::EvoTrees.EvoTypes; MAX_THREADS=1024) where {L<:EvoTrees.GradientRegression}
+    threads = min(MAX_THREADS, size(p, 2))
+    blocks = cld(size(p, 2), threads)
     @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, L)
     CUDA.synchronize()
     return

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -327,6 +327,100 @@ function EvoTrees.update_grads!(
     return
 end
 
+function kernel_gauss_mt_∇!(∇, p, y)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        Y = size(p, 1) ÷ 2
+        w_row = 4 * Y + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for t in 1:Y
+            gb = 2 * (t - 1)
+            hb = 2 * Y + 2 * (t - 1)
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y[t, i]
+            inv = 1 / exp(2 * ls)
+            d = μ - yt
+            ∇[gb+1, i] = d * inv * w
+            ∇[gb+2, i] = (1 - d^2 * inv) * w
+            ∇[hb+1, i] = inv * w
+            ∇[hb+2, i] = 2 * inv * d^2 * w
+        end
+    end
+    return
+end
+
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{EvoTrees.GaussianMLE}, params::EvoTrees.EvoTypes; MAX_THREADS=1024)
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks=blocks threads=threads kernel_gauss_mt_∇!(∇, p, y)
+    CUDA.synchronize()
+    return
+end
+
+function kernel_logistic_∇!(∇::CuDeviceMatrix, p::CuDeviceMatrix, y::CuDeviceVector)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    @inbounds if i <= length(y)
+        w = ∇[5, i]
+        μ = p[1, i]
+        ls = p[2, i]
+        yt = y[i]
+        ∇[1, i] = -tanh((yt - μ) / (2 * exp(ls))) * exp(-ls) * w
+        ∇[2, i] = -(exp(-ls) * (yt - μ) * tanh((yt - μ) / (2 * exp(ls))) - 1) * w
+        ∇[3, i] = sech((yt - μ) / (2 * exp(ls)))^2 / (2 * exp(2 * ls)) * w
+        ∇[4, i] = (exp(-2 * ls) * (μ - yt) *
+                   (μ - yt + exp(ls) * sinh(exp(-ls) * (μ - yt)))) /
+                  (1 + cosh(exp(-ls) * (μ - yt))) * w
+    end
+    return
+end
+
+function EvoTrees.update_grads!(
+    ∇::CuMatrix,
+    p::CuMatrix,
+    y::CuVector,
+    ::Type{EvoTrees.LogisticMLE},
+    params::EvoTrees.EvoTypes;
+    MAX_THREADS=1024,
+)
+    threads = min(MAX_THREADS, length(y))
+    blocks = cld(length(y), threads)
+    @cuda blocks = blocks threads = threads kernel_logistic_∇!(∇, p, y)
+    CUDA.synchronize()
+    return
+end
+
+function kernel_logistic_mt_∇!(∇, p, y)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        Y = size(p, 1) ÷ 2
+        w_row = 4 * Y + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for t in 1:Y
+            gb = 2 * (t - 1)
+            hb = 2 * Y + 2 * (t - 1)
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y[t, i]
+            ∇[gb+1, i] = -tanh((yt - μ) / (2 * exp(ls))) * exp(-ls) * w
+            ∇[gb+2, i] = -(exp(-ls) * (yt - μ) * tanh((yt - μ) / (2 * exp(ls))) - 1) * w
+            ∇[hb+1, i] = sech((yt - μ) / (2 * exp(ls)))^2 / (2 * exp(2 * ls)) * w
+            ∇[hb+2, i] = (exp(-2 * ls) * (μ - yt) *
+                          (μ - yt + exp(ls) * sinh(exp(-ls) * (μ - yt)))) /
+                         (1 + cosh(exp(-ls) * (μ - yt))) * w
+        end
+    end
+    return
+end
+
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{EvoTrees.LogisticMLE}, params::EvoTrees.EvoTypes; MAX_THREADS=1024)
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks=blocks threads=threads kernel_logistic_mt_∇!(∇, p, y)
+    CUDA.synchronize()
+    return
+end
+
 function kernel_gradreg_∇!(∇, p, y, ::Type{EvoTrees.MSE})
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     if i <= size(y, 2)

--- a/ext/EvoTreesCUDAExt/loss.jl
+++ b/ext/EvoTreesCUDAExt/loss.jl
@@ -326,3 +326,24 @@ function EvoTrees.update_grads!(
     CUDA.synchronize()
     return
 end
+
+function kernel_gradreg_∇!(∇, p, y, ::Type{L}) where {L<:EvoTrees.GradientRegression}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        w_row = 2 * K + 1
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            ∇[k, i]   = 2 * (p[k, i] - y[k, i]) * w
+            ∇[K+k, i] = 2 * w
+        end
+    end
+    return
+end
+function EvoTrees.update_grads!(∇::CuMatrix, p::CuMatrix, y::CuMatrix, ::Type{L}, params::EvoTrees.EvoTypes; MAX_THREADS=1024) where {L<:EvoTrees.GradientRegression}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads kernel_gradreg_∇!(∇, p, y, L)
+    CUDA.synchronize()
+    return
+end

--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -40,7 +40,9 @@ end
 # RMSE
 ########################
 EvoTrees.rmse(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat} =
-    sqrt(EvoTrees.rmse(p, y, w; MAX_THREADS, kwargs...))
+    sqrt(EvoTrees.mse(p, y, w, eval; MAX_THREADS, kwargs...))
+EvoTrees.rmse(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat} =
+    sqrt(EvoTrees.mse(p, y, w, eval; MAX_THREADS, kwargs...))
 
 ########################
 # MAE
@@ -56,6 +58,26 @@ function EvoTrees.mae(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVe
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads eval_mae_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_mae_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            acc += abs(p[k, i] - y[k, i])
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.mae(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_mae_mt_kernel!(eval, p, y, w)
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
@@ -77,6 +99,28 @@ function EvoTrees.wmae(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuV
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads eval_wmae_kernel!(eval, p, y, w, T(alpha))
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_wmae_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}, alpha::T) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            acc +=
+                alpha * max(y[k, i] - p[k, i], zero(T)) +
+                (1 - alpha) * max(p[k, i] - y[k, i], zero(T))
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.wmae(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, alpha=0.5, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_wmae_mt_kernel!(eval, p, y, w, T(alpha))
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
@@ -139,6 +183,28 @@ function EvoTrees.logloss(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads eval_logloss_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_logloss_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            pred = EvoTrees.sigmoid(p[k, i])
+            yk = y[k, i]
+            acc += -yk * log(pred) + (yk - 1) * log(1 - pred)
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.logloss(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_logloss_mt_kernel!(eval, p, y, w)
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
@@ -228,6 +294,29 @@ function EvoTrees.poisson(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::
     return sum(eval) / sum(w)
 end
 
+function eval_poisson_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    ϵ = eps(T(1e-7))
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            pred = exp(p[k, i])
+            yk = y[k, i]
+            acc += 2 * (yk * log(yk / pred + ϵ) + pred - yk)
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.poisson(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_poisson_mt_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
 ########################
 # Gamma Deviance
 ########################
@@ -244,6 +333,28 @@ function EvoTrees.gamma(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::Cu
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads eval_gamma_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_gamma_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            pred = exp(p[k, i])
+            yk = y[k, i]
+            acc += 2 * (log(pred / yk) + yk / pred - 1)
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.gamma(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_gamma_mt_kernel!(eval, p, y, w)
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
@@ -266,6 +377,29 @@ function EvoTrees.tweedie(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::
     threads = min(MAX_THREADS, length(y))
     blocks = cld(length(y), threads)
     @cuda blocks = blocks threads = threads eval_tweedie_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_tweedie_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    rho = T(1.5)
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            pred = exp(p[k, i])
+            yk = y[k, i]
+            acc += 2 * (yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) + pred^(2 - rho) / (2 - rho))
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.tweedie(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_tweedie_mt_kernel!(eval, p, y, w)
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end

--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -141,6 +141,52 @@ function EvoTrees.gaussian_mle(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, e
     return sum(eval) / sum(w)
 end
 
+function eval_gaussian_mt_kernel!(eval, p, y, w)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        Y = size(p, 1) ÷ 2
+        acc = zero(eltype(eval))
+        @inbounds for t in 1:Y
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y[t, i]
+            acc += -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+        end
+        @inbounds eval[i] = w[i] * acc / Y
+    end
+    return nothing
+end
+function EvoTrees.gaussian_mle(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_gaussian_mt_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
+function eval_logistic_mt_kernel!(eval, p, y, w)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        Y = size(p, 1) ÷ 2
+        acc = zero(eltype(eval))
+        @inbounds for t in 1:Y
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y[t, i]
+            acc += log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
+        end
+        @inbounds eval[i] = w[i] * acc / Y
+    end
+    return nothing
+end
+function EvoTrees.logistic_mle(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_logistic_mt_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
 ########################
 # Poisson Deviance
 ########################

--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -1,129 +1,73 @@
-########################
-# MSE
-########################
-function eval_mse_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds eval[i] = w[i] * (p[1, i] - y[i])^2
-    end
-    return nothing
-end
-function EvoTrees.mse(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_mse_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
+@inline _metric_value(::Type{EvoTrees.MSE}, pk, yk, alpha) = (pk - yk)^2
+@inline _metric_value(::Type{EvoTrees.MAE}, pk, yk, alpha) = abs(pk - yk)
+
+@inline function _metric_value(::Type{EvoTrees.Quantile}, pk, yk, alpha)
+    return alpha * max(yk - pk, zero(pk)) + (1 - alpha) * max(pk - yk, zero(pk))
 end
 
-function eval_mse_mt_kernel!(eval, p, y, w)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        K = size(p, 1)
-        acc = zero(eltype(eval))
-        @inbounds for k in 1:K
-            acc += (p[k, i] - y[k, i])^2
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.mse(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_mse_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
+@inline function _metric_value(::Type{EvoTrees.LogLoss}, pk, yk, alpha)
+    pred = EvoTrees.sigmoid(pk)
+    return -yk * log(pred) + (yk - 1) * log(1 - pred)
 end
 
-########################
-# RMSE
-########################
-EvoTrees.rmse(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat} =
-    sqrt(EvoTrees.mse(p, y, w, eval; MAX_THREADS, kwargs...))
-EvoTrees.rmse(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat} =
-    sqrt(EvoTrees.mse(p, y, w, eval; MAX_THREADS, kwargs...))
-
-########################
-# MAE
-########################
-function eval_mae_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds eval[i] = w[i] * abs(p[1, i] - y[i])
-    end
-    return nothing
-end
-function EvoTrees.mae(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_mae_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
+@inline function _metric_value(::Type{EvoTrees.Poisson}, pk, yk, alpha)
+    pred = exp(pk)
+    ϵ = eps(typeof(pk)(1e-7))
+    return 2 * (yk * log(yk / pred + ϵ) + pred - yk)
 end
 
-function eval_mae_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+@inline function _metric_value(::Type{EvoTrees.Gamma}, pk, yk, alpha)
+    pred = exp(pk)
+    return 2 * (log(pred / yk) + yk / pred - 1)
+end
+
+@inline function _metric_value(::Type{EvoTrees.Tweedie}, pk, yk, alpha)
+    rho = oftype(pk, 1.5)
+    pred = exp(pk)
+    return 2 * (yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) + pred^(2 - rho) / (2 - rho))
+end
+
+@inline _mle2p_metric_value(::Type{EvoTrees.GaussianMLE}, μ, ls, yt) = -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+@inline _mle2p_metric_value(::Type{EvoTrees.LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
+
+########################
+# Pointwise metrics
+########################
+@inline _metric_target_count(p, y::CuDeviceVector) = 1
+@inline _metric_target_count(p, y::CuDeviceMatrix) = size(p, 1)
+
+function eval_metric_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y, w::CuDeviceVector{T}, ::Type{M}, alpha::T) where {T<:AbstractFloat,M}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        K = size(p, 1)
+    if i <= length(w)
+        K = _metric_target_count(p, y)
         acc = zero(T)
         @inbounds for k in 1:K
-            acc += abs(p[k, i] - y[k, i])
+            acc += _metric_value(M, p[k, i], _cuda_target(y, k, i), alpha)
         end
         @inbounds eval[i] = w[i] * acc / K
     end
     return nothing
 end
-function EvoTrees.mae(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_mae_mt_kernel!(eval, p, y, w)
+
+function _eval_metric(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}, ::Type{M}; MAX_THREADS=1024, alpha=0.5, kwargs...) where {T<:AbstractFloat,M}
+    threads = min(MAX_THREADS, length(w))
+    blocks = cld(length(w), threads)
+    @cuda blocks = blocks threads = threads eval_metric_kernel!(eval, p, y, w, M, T(alpha))
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
 
-########################
-# WMAE
-########################
-function eval_wmae_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}, alpha::T) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds eval[i] = w[i] * (
-            alpha * max(y[i] - p[1, i], zero(T)) +
-            (1 - alpha) * max(p[1, i] - y[i], zero(T))
-        )
-    end
-    return nothing
-end
-function EvoTrees.wmae(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, alpha=0.5, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_wmae_kernel!(eval, p, y, w, T(alpha))
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
+EvoTrees.mse(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.MSE; kwargs...)
 
-function eval_wmae_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}, alpha::T) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        K = size(p, 1)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            acc +=
-                alpha * max(y[k, i] - p[k, i], zero(T)) +
-                (1 - alpha) * max(p[k, i] - y[k, i], zero(T))
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.wmae(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, alpha=0.5, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_wmae_mt_kernel!(eval, p, y, w, T(alpha))
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
+EvoTrees.rmse(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    sqrt(EvoTrees.mse(p, y, w, eval; kwargs...))
+
+EvoTrees.mae(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.MAE; kwargs...)
+
+EvoTrees.wmae(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.Quantile; kwargs...)
 
 ########################
 # MultiQuantile
@@ -141,9 +85,8 @@ function eval_multiquantile_kernel!(
         yi = y[i]
         acc = zero(T)
         @inbounds for k in 1:K
-            diff = yi - p[k, i]
             alpha = alphas[k]
-            acc += alpha * max(diff, zero(T)) + (1 - alpha) * max(-diff, zero(T))
+            acc += _metric_value(EvoTrees.Quantile, p[k, i], yi, alpha)
         end
         @inbounds eval[i] = w[i] * acc / K
     end
@@ -168,241 +111,50 @@ function EvoTrees.multiquantile(
     return sum(eval) / sum(w)
 end
 
-########################
-# Logloss
-########################
-function eval_logloss_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds pred = EvoTrees.sigmoid(p[1, i])
-        @inbounds eval[i] = w[i] * (-y[i] * log(pred) + (y[i] - 1) * log(1 - pred))
-    end
-    return nothing
-end
-function EvoTrees.logloss(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_logloss_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
+EvoTrees.logloss(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.LogLoss; kwargs...)
 
-function eval_logloss_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
+EvoTrees.poisson(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.Poisson; kwargs...)
+
+EvoTrees.gamma(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.Gamma; kwargs...)
+
+EvoTrees.tweedie(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_metric(p, y, w, eval, EvoTrees.Tweedie; kwargs...)
+
+########################
+# Two-parameter MLE metrics
+########################
+@inline _mle2p_target_count(p, y::CuDeviceVector) = 1
+@inline _mle2p_target_count(p, y::CuDeviceMatrix) = size(p, 1) ÷ 2
+
+function eval_mle2p_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y, w::CuDeviceVector{T}, ::Type{M}) where {T<:AbstractFloat,M<:EvoTrees.MLE2P}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        K = size(p, 1)
+    if i <= length(w)
+        Y = _mle2p_target_count(p, y)
         acc = zero(T)
-        @inbounds for k in 1:K
-            pred = EvoTrees.sigmoid(p[k, i])
-            yk = y[k, i]
-            acc += -yk * log(pred) + (yk - 1) * log(1 - pred)
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.logloss(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_logloss_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-########################
-# Gaussian
-########################
-function eval_gaussian_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds eval[i] = -w[i] * (p[2, i] + (y[i] - p[1, i])^2 / (2 * exp(2 * p[2, i])))
-    end
-    return nothing
-end
-function EvoTrees.gaussian_mle(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_gaussian_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-function eval_gaussian_mt_kernel!(eval, p, y, w)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        Y = size(p, 1) ÷ 2
-        acc = zero(eltype(eval))
         @inbounds for t in 1:Y
-            μ = p[2t-1, i]
-            ls = p[2t, i]
-            yt = y[t, i]
-            acc += -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+            acc += _mle2p_metric_value(M, p[2t-1, i], p[2t, i], _cuda_target(y, t, i))
         end
         @inbounds eval[i] = w[i] * acc / Y
     end
     return nothing
 end
-function EvoTrees.gaussian_mle(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_gaussian_mt_kernel!(eval, p, y, w)
+
+function _eval_mle2p_metric(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}, ::Type{M}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat,M<:EvoTrees.MLE2P}
+    threads = min(MAX_THREADS, length(w))
+    blocks = cld(length(w), threads)
+    @cuda blocks = blocks threads = threads eval_mle2p_kernel!(eval, p, y, w, M)
     CUDA.synchronize()
     return sum(eval) / sum(w)
 end
 
-function eval_logistic_mt_kernel!(eval, p, y, w)
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        Y = size(p, 1) ÷ 2
-        acc = zero(eltype(eval))
-        @inbounds for t in 1:Y
-            μ = p[2t-1, i]
-            ls = p[2t, i]
-            yt = y[t, i]
-            acc += log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
-        end
-        @inbounds eval[i] = w[i] * acc / Y
-    end
-    return nothing
-end
-function EvoTrees.logistic_mle(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_logistic_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
+EvoTrees.gaussian_mle(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_mle2p_metric(p, y, w, eval, EvoTrees.GaussianMLE; kwargs...)
 
-########################
-# Poisson Deviance
-########################
-function eval_poisson_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    ϵ = eps(T(1e-7))
-    if i <= length(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds eval[i] = w[i] * 2 * (y[i] * log(y[i] / pred + ϵ) + pred - y[i])
-    end
-    return nothing
-end
-
-function EvoTrees.poisson(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_poisson_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-function eval_poisson_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    ϵ = eps(T(1e-7))
-    if i <= size(y, 2)
-        K = size(p, 1)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            pred = exp(p[k, i])
-            yk = y[k, i]
-            acc += 2 * (yk * log(yk / pred + ϵ) + pred - yk)
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.poisson(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_poisson_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-########################
-# Gamma Deviance
-########################
-function eval_gamma_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= length(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds eval[i] = w[i] * 2 * (log(pred / y[i]) + y[i] / pred - 1)
-    end
-    return nothing
-end
-
-function EvoTrees.gamma(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_gamma_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-function eval_gamma_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    if i <= size(y, 2)
-        K = size(p, 1)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            pred = exp(p[k, i])
-            yk = y[k, i]
-            acc += 2 * (log(pred / yk) + yk / pred - 1)
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.gamma(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_gamma_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-########################
-# Tweedie Deviance
-########################
-function eval_tweedie_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceVector{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    rho = T(1.5)
-    if i <= length(y)
-        pred = exp(p[1, i])
-        @inbounds eval[i] = w[i] * 2 * (y[i]^(2 - rho) / (1 - rho) / (2 - rho) - y[i] * pred^(1 - rho) / (1 - rho) + pred^(2 - rho) / (2 - rho))
-
-    end
-    return nothing
-end
-
-function EvoTrees.tweedie(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, length(y))
-    blocks = cld(length(y), threads)
-    @cuda blocks = blocks threads = threads eval_tweedie_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
-
-function eval_tweedie_mt_kernel!(eval::CuDeviceVector{T}, p::CuDeviceMatrix{T}, y::CuDeviceMatrix{T}, w::CuDeviceVector{T}) where {T<:AbstractFloat}
-    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-    rho = T(1.5)
-    if i <= size(y, 2)
-        K = size(p, 1)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            pred = exp(p[k, i])
-            yk = y[k, i]
-            acc += 2 * (yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) + pred^(2 - rho) / (2 - rho))
-        end
-        @inbounds eval[i] = w[i] * acc / K
-    end
-    return nothing
-end
-function EvoTrees.tweedie(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
-    threads = min(MAX_THREADS, size(y, 2))
-    blocks = cld(size(y, 2), threads)
-    @cuda blocks = blocks threads = threads eval_tweedie_mt_kernel!(eval, p, y, w)
-    CUDA.synchronize()
-    return sum(eval) / sum(w)
-end
+EvoTrees.logistic_mle(p::CuMatrix{T}, y::Union{CuVector{T},CuMatrix{T}}, w::CuVector{T}, eval::CuVector{T}; kwargs...) where {T<:AbstractFloat} =
+    _eval_mle2p_metric(p, y, w, eval, EvoTrees.LogisticMLE; kwargs...)
 
 ########################
 # mlogloss

--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -16,6 +16,26 @@ function EvoTrees.mse(p::CuMatrix{T}, y::CuVector{T}, w::CuVector{T}, eval::CuVe
     return sum(eval) / sum(w)
 end
 
+function eval_mse_mt_kernel!(eval, p, y, w)
+    i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    if i <= size(y, 2)
+        K = size(p, 1)
+        acc = zero(eltype(eval))
+        @inbounds for k in 1:K
+            acc += (p[k, i] - y[k, i])^2
+        end
+        @inbounds eval[i] = w[i] * acc / K
+    end
+    return nothing
+end
+function EvoTrees.mse(p::CuMatrix{T}, y::CuMatrix{T}, w::CuVector{T}, eval::CuVector{T}; MAX_THREADS=1024, kwargs...) where {T<:AbstractFloat}
+    threads = min(MAX_THREADS, size(y, 2))
+    blocks = cld(size(y, 2), threads)
+    @cuda blocks = blocks threads = threads eval_mse_mt_kernel!(eval, p, y, w)
+    CUDA.synchronize()
+    return sum(eval) / sum(w)
+end
+
 ########################
 # RMSE
 ########################

--- a/ext/EvoTreesCUDAExt/predict.jl
+++ b/ext/EvoTreesCUDAExt/predict.jl
@@ -37,13 +37,16 @@ function predict_kernel!(
 ) where {T}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     nid = 1
+    K = size(pred, 1)
     @inbounds if i <= size(pred, 2)
         @inbounds while split[nid]
             feat = feats[nid]
             cond = feattypes[feat] ? x_bin[i, feat] <= cond_bins[nid] : x_bin[i, feat] == cond_bins[nid]
             nid = (nid << 1) + Int(!cond)
         end
-        pred[1, i] += leaf_pred[1, nid]
+        @inbounds for k in 1:K
+            pred[k, i] += leaf_pred[k, nid]
+        end
     end
     return nothing
 end

--- a/ext/EvoTreesCUDAExt/predict.jl
+++ b/ext/EvoTreesCUDAExt/predict.jl
@@ -88,14 +88,17 @@ function predict_kernel!(
 ) where {T}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     nid = 1
+    Y = size(pred, 1) ÷ 2
     @inbounds if i <= size(pred, 2)
         @inbounds while split[nid]
             feat = feats[nid]
             cond = feattypes[feat] ? x_bin[i, feat] <= cond_bins[nid] : x_bin[i, feat] == cond_bins[nid]
             nid = (nid << 1) + Int(!cond)
         end
-        pred[1, i] += leaf_pred[1, nid]
-        pred[2, i] = max(T(-15), pred[2, i] + leaf_pred[2, nid])
+        @inbounds for t in 1:Y
+            pred[2t-1, i] += leaf_pred[2t-1, nid]
+            pred[2t, i] = max(T(-15), pred[2t, i] + leaf_pred[2t, nid])
+        end
     end
     return nothing
 end
@@ -168,7 +171,7 @@ function EvoTrees._predict(
     elseif L ∈ [EvoTrees.Poisson, EvoTrees.Gamma, EvoTrees.Tweedie]
         pred .= exp.(pred)
     elseif L in [EvoTrees.GaussianMLE, EvoTrees.LogisticMLE]
-        pred[2, :] .= exp.(pred[2, :])
+        pred[2:2:end, :] .= exp.(pred[2:2:end, :])
     elseif L == EvoTrees.MLogLoss
         EvoTrees.softmax!(pred)
     end

--- a/ext/EvoTreesCUDAExt/predict.jl
+++ b/ext/EvoTreesCUDAExt/predict.jl
@@ -215,5 +215,9 @@ end
 
 function EvoTrees.pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTrees.EvoTypes, ∇::CuMatrix, is) where {L<:EvoTrees.Quantile,T}
     ϵ = eps(T)
-    p[1, n] = params.eta / params.bagging_size * quantile_gpu(view(∇, 2, is), params.alpha) / (1 + params.lambda + params.L2 / ∑[3])
+    K = size(p, 1)
+    denom = 1 + params.lambda + params.L2 / ∑[end]
+    @inbounds for k in 1:K
+        p[k, n] = params.eta / params.bagging_size * quantile_gpu(view(∇, K + k, is), params.alpha) / max(ϵ, denom)
+    end
 end

--- a/ext/EvoTreesCUDAExt/predict.jl
+++ b/ext/EvoTreesCUDAExt/predict.jl
@@ -64,13 +64,16 @@ function predict_kernel!(
 ) where {T}
     i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
     nid = 1
+    K = size(pred, 1)
     @inbounds if i <= size(pred, 2)
         @inbounds while split[nid]
             feat = feats[nid]
             cond = feattypes[feat] ? x_bin[i, feat] <= cond_bins[nid] : x_bin[i, feat] == cond_bins[nid]
             nid = (nid << 1) + Int(!cond)
         end
-        pred[1, i] = clamp(pred[1, i] + leaf_pred[1, nid], T(-15), T(15))
+        @inbounds for k in 1:K
+            pred[k, i] = clamp(pred[k, i] + leaf_pred[k, nid], T(-15), T(15))
+        end
     end
     return nothing
 end

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -21,13 +21,15 @@ function CallBack(
     T = Float32
     _weight_name = isnothing(weight_name) ? Symbol("") : Symbol(weight_name)
     _offset_name = isnothing(offset_name) ? Symbol("") : Symbol(offset_name)
-    _target_name = Symbol(target_name)
+    _target_names = target_name isa AbstractVector ? Symbol.(target_name) : [Symbol(target_name)]
 
     x_bin = binarize(deval; feature_names=m.info[:feature_names], edges=m.info[:edges])
     nobs = length(Tables.getcolumn(deval, 1))
     p = zeros(T, K, nobs)
 
-    y_eval = Tables.getcolumn(deval, _target_name)
+    y_eval = length(_target_names) == 1 ?
+        Tables.getcolumn(deval, _target_names[1]) :
+        permutedims(reduce(hcat, [Tables.getcolumn(deval, t) for t in _target_names]))
 
     if L == MLogLoss
         if eltype(y_eval) <: CategoricalValue
@@ -45,7 +47,7 @@ function CallBack(
     end
     feval = metric_dict[params.metric]
     V = device_array_type(device)
-    w = isnothing(weight_name) ? device_ones(device, T, length(y)) : V{T}(Tables.getcolumn(deval, _weight_name))
+    w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(deval, _weight_name))
     metric_kwargs = (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)
@@ -95,7 +97,7 @@ function CallBack(
     end
     feval = metric_dict[params.metric]
     V = device_array_type(device)
-    w = isnothing(w_eval) ? device_ones(device, T, length(y)) : V{T}(w_eval)
+    w = isnothing(w_eval) ? device_ones(device, T, size(x_eval, 1)) : V{T}(w_eval)
     metric_kwargs = (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)

--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -348,32 +348,6 @@ end
 
 """
     update_hist!
-        MLE2P
-"""
-function update_hist!(
-    ::Type{L},
-    hist::Array,
-    ∇::Matrix,
-    x_bin::Matrix,
-    is::AbstractVector,
-    js::AbstractVector,
-) where {L<:MLE2P}
-    hist .= 0
-    @threads for j in js
-        @inbounds @simd for i in is
-            bin = x_bin[i, j]
-            hist[1, bin, j] += ∇[1, i]
-            hist[2, bin, j] += ∇[2, i]
-            hist[3, bin, j] += ∇[3, i]
-            hist[4, bin, j] += ∇[4, i]
-            hist[5, bin, j] += ∇[5, i]
-        end
-    end
-    return nothing
-end
-
-"""
-    update_hist!
         
 Generic fallback - Softmax
 """

--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -324,12 +324,23 @@ function update_hist!(
     js::AbstractVector,
 ) where {L<:GradientRegression}
     hist .= 0
-    @threads for j in js
-        @inbounds @simd for i in is
-            bin = x_bin[i, j]
-            hist[1, bin, j] += ∇[1, i]
-            hist[2, bin, j] += ∇[2, i]
-            hist[3, bin, j] += ∇[3, i]
+    if size(hist, 1) == 3
+        @threads for j in js
+            @inbounds @simd for i in is
+                bin = x_bin[i, j]
+                hist[1, bin, j] += ∇[1, i]
+                hist[2, bin, j] += ∇[2, i]
+                hist[3, bin, j] += ∇[3, i]
+            end
+        end
+    else
+        @threads for j in js
+            @inbounds for i in is
+                bin = x_bin[i, j]
+                @simd for k in axes(∇, 1)
+                    hist[k, bin, j] += ∇[k, i]
+                end
+            end
         end
     end
     return nothing

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -356,7 +356,7 @@ end
     fit(
         params::EvoTypes{L};
         x_train::AbstractMatrix, 
-        y_train::AbstractVector, 
+        y_train::AbstractVecOrMat, 
         w_train=nothing, 
         offset_train=nothing,
         x_eval=nothing, 
@@ -382,11 +382,11 @@ Main training function. Performs model fitting given configuration `params`, `x_
 # Keyword arguments
 
 - `x_train::Matrix`: training data of size `[#observations, #features]`. 
-- `y_train::Vector`: vector of train targets of length `#observations`.
+- `y_train::VecOrMat`: vector or matrix of train targets of length `#observations` or size `(#targets, #observations)`.
 - `w_train::Vector`: vector of train weights of length `#observations`. If `nothing`, a vector of ones is assumed.
 - `offset_train::VecOrMat`: offset for the training data. Should match the size of the predictions.
 - `x_eval::Matrix`: evaluation data of size `[#observations, #features]`. 
-- `y_eval::Vector`: vector of evaluation targets of length `#observations`.
+- `y_eval::VecOrMat`: vector or matrix of evaluation targets of length `#observations` or size `(#targets, #observations)`.
 - `w_eval::Vector`: vector of evaluation weights of length `#observations`. Defaults to `nothing` (assumes a vector of 1s).
 - `offset_eval::VecOrMat`: evaluation data offset. Should match the size of the predictions.
 - `feature_names = nothing`: the names of the `x_train` features. If provided, should be a vector of string with `length(feature_names) = size(x_train, 2)`.
@@ -396,7 +396,7 @@ Main training function. Performs model fitting given configuration `params`, `x_
 function fit(
     params::EvoTypes;
     x_train::AbstractMatrix,
-    y_train::AbstractVector,
+    y_train::AbstractVecOrMat,
     w_train=nothing,
     offset_train=nothing,
     x_eval=nothing,

--- a/src/init.jl
+++ b/src/init.jl
@@ -10,11 +10,12 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     T = Float32
     L = _loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: Union{GradientRegression, MLE2P, MAE, Quantile})
-        error("Multi-target (vector target_name) is only supported for single-parameter " *
-              "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
+    if (y_train isa AbstractMatrix) && !(L <: Union{GradientRegression, MLE2P, MAE, Quantile, Cred})
+        error("Multi-target (matrix target) is supported for gradient-regression losses " *
+              "(mse, logloss, poisson, gamma, tweedie), mae, quantile, the MLE losses " *
+              "(gaussian_mle, logistic_mle), and credibility losses (cred_var, cred_std). " *
+              "Got loss $(params.loss).")
     end
-
     target_levels = nothing
     target_isordered = false
     if L == LogLoss
@@ -99,6 +100,18 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         y = T.(y_train)
         μ = T.(quantile.(Ref(y), params.alphas))
     elseif L <: Union{MAE,Quantile}
+        @assert eltype(y_train) <: Real
+        if y_train isa AbstractVector
+            K = 1
+            y = T.(y_train)
+            μ = T[mean(y)]
+        else
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[mean(view(y, k, :)) for k in 1:K]
+        end
+    
+    elseif L <: Cred
         @assert eltype(y_train) <: Real
         if y_train isa AbstractVector
             K = 1

--- a/src/init.jl
+++ b/src/init.jl
@@ -20,20 +20,26 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     if L == LogLoss
         @assert eltype(y_train) <: Real && minimum(y_train) >= 0 && maximum(y_train) <= 1
         if y_train isa AbstractVector
-            K = 1; y = reshape(T.(y_train), 1, :)
+            K = 1
+            y = T.(y_train)
+            μ = T[logit(mean(y))]
         else
-            K = size(y_train, 1); y = T.(y_train)
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[logit(mean(view(y, k, :))) for k in 1:K]
         end
-        μ = T[logit(mean(view(y, k, :))) for k in 1:K]
         !isnothing(offset) && (offset .= logit.(offset))
     elseif L in [Poisson, Gamma, Tweedie]
         @assert eltype(y_train) <: Real
         if y_train isa AbstractVector
-            K = 1; y = reshape(T.(y_train), 1, :)
+            K = 1
+            y = T.(y_train)
+            μ = T[log(mean(y))]
         else
-            K = size(y_train, 1); y = T.(y_train)
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[log(mean(view(y, k, :))) for k in 1:K]
         end
-        μ = T[log(mean(view(y, k, :))) for k in 1:K]
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == MLogLoss
         if eltype(y_train) <: CategoricalValue
@@ -72,11 +78,14 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         @assert eltype(y_train) <: Real
         if L <: GradientRegression
             if y_train isa AbstractVector
-                K = 1; y = reshape(T.(y_train), 1, :)
+                K = 1
+                y = T.(y_train)
+                μ = T[mean(y)]
             else
-                K = size(y_train, 1); y = T.(y_train)
+                K = size(y_train, 1)
+                y = T.(y_train)
+                μ = T[mean(view(y, k, :)) for k in 1:K]
             end
-            μ = T[mean(view(y, k, :)) for k in 1:K]
         else
             K = 1
             y = T.(y_train)

--- a/src/init.jl
+++ b/src/init.jl
@@ -10,19 +10,30 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     T = Float32
     L = _loss2type_dict[params.loss]
 
+    if (y_train isa AbstractMatrix) && !(L <: GradientRegression)
+        error("Multi-target (vector target_name) is only supported for single-parameter " *
+              "regression losses (mse, logloss, poisson, gamma, tweedie). Got loss $(params.loss).")
+    end
+
     target_levels = nothing
     target_isordered = false
     if L == LogLoss
         @assert eltype(y_train) <: Real && minimum(y_train) >= 0 && maximum(y_train) <= 1
-        K = 1
-        y = T.(y_train)
-        μ = [logit(mean(y))]
+        if y_train isa AbstractVector
+            K = 1; y = reshape(T.(y_train), 1, :)
+        else
+            K = size(y_train, 1); y = T.(y_train)
+        end
+        μ = T[logit(mean(view(y, k, :))) for k in 1:K]
         !isnothing(offset) && (offset .= logit.(offset))
     elseif L in [Poisson, Gamma, Tweedie]
         @assert eltype(y_train) <: Real
-        K = 1
-        y = T.(y_train)
-        μ = fill(log(mean(y)), 1)
+        if y_train isa AbstractVector
+            K = 1; y = reshape(T.(y_train), 1, :)
+        else
+            K = size(y_train, 1); y = T.(y_train)
+        end
+        μ = T[log(mean(view(y, k, :))) for k in 1:K]
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == MLogLoss
         if eltype(y_train) <: CategoricalValue
@@ -59,15 +70,24 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         μ = T.(quantile.(Ref(y), params.alphas))
     else
         @assert eltype(y_train) <: Real
-        K = 1
-        y = T.(y_train)
-        μ = [mean(y)]
+        if L <: GradientRegression
+            if y_train isa AbstractVector
+                K = 1; y = reshape(T.(y_train), 1, :)
+            else
+                K = size(y_train, 1); y = T.(y_train)
+            end
+            μ = T[mean(view(y, k, :)) for k in 1:K]
+        else
+            K = 1
+            y = T.(y_train)
+            μ = [mean(y)]
+        end
     end
     μ = T.(μ)
 
     # force a neutral/zero bias/initial tree when offset is specified
     !isnothing(offset) && (μ .= 0)
-    @assert (length(y) == length(w) && minimum(w) > 0)
+    @assert (size(y, ndims(y)) == length(w) && minimum(w) > 0)
 
     # initialize preds
     pred = zeros(T, K, nobs)
@@ -159,7 +179,7 @@ function init(
     schema = Tables.schema(dtrain)
     _weight_name = isnothing(weight_name) ? Symbol("") : Symbol(weight_name)
     _offset_name = isnothing(offset_name) ? Symbol("") : Symbol(offset_name)
-    _target_name = Symbol(target_name)
+    _target_names = target_name isa AbstractVector ? Symbol.(target_name) : [Symbol(target_name)]
     if isnothing(feature_names)
         feature_names = Symbol[]
         for i in eachindex(schema.names)
@@ -167,7 +187,7 @@ function init(
                 push!(feature_names, schema.names[i])
             end
         end
-        feature_names = setdiff(feature_names, union([_target_name], [_weight_name], [_offset_name]))
+        feature_names = setdiff(feature_names, union(_target_names, [_weight_name], [_offset_name]))
     else
         isa(feature_names, String) ? feature_names = [feature_names] : nothing
         feature_names = Symbol.(feature_names)
@@ -180,12 +200,16 @@ function init(
 
     T = Float32
     nobs = length(Tables.getcolumn(dtrain, 1))
-    y_train = Tables.getcolumn(dtrain, _target_name)
+    y_train = length(_target_names) == 1 ?
+        Tables.getcolumn(dtrain, _target_names[1]) :
+        permutedims(reduce(hcat, [Tables.getcolumn(dtrain, t) for t in _target_names]))
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(dtrain, _weight_name))
     offset = isnothing(offset_name) ? nothing : V{T}(Tables.getcolumn(dtrain, _offset_name))
 
     m, cache = init_core(params, device, dtrain, feature_names, y_train, w, offset)
+
+    m.info[:target_names] = _target_names
 
     return m, cache
 end
@@ -198,7 +222,7 @@ device_array_type(::Type{<:CPU}) = Array
     init(
         params::EvoTypes,
         x_train::AbstractMatrix,
-        y_train::AbstractVector,
+        y_train::AbstractVecOrMat,
         device::Type{<:Device}=CPU;
         feature_names=nothing,
         w_train=nothing,
@@ -210,7 +234,7 @@ Initialise EvoTree
 function init(
     params::EvoTypes,
     x_train::AbstractMatrix,
-    y_train::AbstractVector,
+    y_train::AbstractVecOrMat,
     device::Type{<:Device}=CPU;
     feature_names=nothing,
     w_train=nothing,

--- a/src/init.jl
+++ b/src/init.jl
@@ -10,9 +10,9 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     T = Float32
     L = _loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: GradientRegression)
+    if (y_train isa AbstractMatrix) && !(L <: Union{GradientRegression, MLE2P})
         error("Multi-target (vector target_name) is only supported for single-parameter " *
-              "regression losses (mse, logloss, poisson, gamma, tweedie). Got loss $(params.loss).")
+              "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
     end
 
     target_levels = nothing
@@ -59,16 +59,40 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         !isnothing(offset) && (offset .= log.(offset))
     elseif L == GaussianMLE
         @assert eltype(y_train) <: Real
-        K = 2
-        y = T.(y_train)
-        μ = [mean(y), log(std(y))]
-        !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        if y_train isa AbstractVector
+            K = 2
+            y = T.(y_train)
+            μ = [mean(y), log(std(y))]
+            !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        else
+            Y = size(y_train, 1)
+            K = 2 * Y
+            y = T.(y_train)
+            μ = T[]
+            for t in 1:Y
+                yt = view(y, t, :)
+                push!(μ, mean(yt), log(std(yt)))
+            end
+            !isnothing(offset) && (offset[:, 2:2:end] .= log.(offset[:, 2:2:end]))
+        end
     elseif L == LogisticMLE
         @assert eltype(y_train) <: Real
-        K = 2
-        y = T.(y_train)
-        μ = [mean(y), log(std(y) * sqrt(3) / π)]
-        !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        if y_train isa AbstractVector
+            K = 2
+            y = T.(y_train)
+            μ = [mean(y), log(std(y) * sqrt(3) / π)]
+            !isnothing(offset) && (offset[:, 2] .= log.(offset[:, 2]))
+        else
+            Y = size(y_train, 1)
+            K = 2 * Y
+            y = T.(y_train)
+            μ = T[]
+            for t in 1:Y
+                yt = view(y, t, :)
+                push!(μ, mean(yt), log(std(yt) * sqrt(3) / π))
+            end
+            !isnothing(offset) && (offset[:, 2:2:end] .= log.(offset[:, 2:2:end]))
+        end
     elseif L == MultiQuantile
         @assert eltype(y_train) <: Real
         K = length(params.alphas)

--- a/src/init.jl
+++ b/src/init.jl
@@ -10,7 +10,7 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     T = Float32
     L = _loss2type_dict[params.loss]
 
-    if (y_train isa AbstractMatrix) && !(L <: Union{GradientRegression, MLE2P})
+    if (y_train isa AbstractMatrix) && !(L <: Union{GradientRegression, MLE2P, MAE, Quantile})
         error("Multi-target (vector target_name) is only supported for single-parameter " *
               "regression losses and MLE losses (gaussian_mle, logistic_mle). Got loss $(params.loss).")
     end
@@ -98,6 +98,17 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         K = length(params.alphas)
         y = T.(y_train)
         μ = T.(quantile.(Ref(y), params.alphas))
+    elseif L <: Union{MAE,Quantile}
+        @assert eltype(y_train) <: Real
+        if y_train isa AbstractVector
+            K = 1
+            y = T.(y_train)
+            μ = T[mean(y)]
+        else
+            K = size(y_train, 1)
+            y = T.(y_train)
+            μ = T[mean(view(y, k, :)) for k in 1:K]
+        end
     else
         @assert eltype(y_train) <: Real
         if L <: GradientRegression

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -139,10 +139,16 @@ function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{MultiQ
 end
 
 # Credibility-based
-function update_grads!(∇::Matrix, p::Matrix{T}, y::Vector{T}, ::Type{<:Cred}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds ∇[1, i] = (y[i] - p[1, i]) * ∇[3, i]
-        @inbounds ∇[2, i] = (y[i] - p[1, i])^2 * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{<:Cred}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            d = _target(y, k, i) - p[k, i]
+            ∇[k, i] = d * w
+            ∇[K+k, i] = d^2 * w
+        end
     end
 end
 
@@ -310,37 +316,54 @@ function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V)
 end
 
 # CredVar: ratio of variance
-# VHM = E²[X] = (∑1 / ∑3)²
-# EVPV = E[X^2] - E²[X] = ∑2 / ∑3 - VHM
-@inline function _get_cred(::Type{CredVar}, params::EvoTypes, ∑::AbstractVector{T}) where {T}
-    ϵ = eps(eltype(∑))
-    VHM = (∑[1] / ∑[3])^2
-    EVPV = max(ϵ, (∑[2] / ∑[3] - VHM))
+# VHM = E²[X] = (m1 / w)²
+# EVPV = E[X^2] - E²[X] = m2 / w - VHM
+@inline function _cred_Z(::Type{CredVar}, m1, m2, w, ϵ)
+    VHM = (m1 / w)^2
+    EVPV = max(ϵ, m2 / w - VHM)
     return VHM / (VHM + EVPV)
 end
 
-# CredStd: ratio of std dev 
-# VHM = E²[X] = (∑1 / ∑3)²
-# EVPV = E[X^2] - E²[X] = ∑2 / ∑3 - VHM
-@inline function _get_cred(::Type{CredStd}, params::EvoTypes, ∑::AbstractVector{T}) where {T}
-    ϵ = eps(eltype(∑))
-    VHM = (∑[1] / ∑[3])^2
-    EVPV = max(ϵ, (∑[2] / ∑[3] - VHM))
+# CredStd: ratio of std dev
+@inline function _cred_Z(::Type{CredStd}, m1, m2, w, ϵ)
+    VHM = (m1 / w)^2
+    EVPV = max(ϵ, m2 / w - VHM)
     return sqrt(VHM) / (sqrt(VHM) + sqrt(EVPV))
 end
 
-# gain for Cred
-function get_gain(::Type{L}, params::EvoTypes, ∑::AbstractVector{T}) where {L<:Cred,T}
-    Z = _get_cred(L, params, ∑)
-    return Z * abs(∑[1]) / (1 + params.L2 / ∑[3])
+@inline function _get_cred(L::Type{<:Cred}, params::EvoTypes, ∑::AbstractVector{T}) where {T}
+    ϵ = eps(T)
+    K = (length(∑) - 1) ÷ 2
+    w = ∑[end]
+    return _cred_Z(L, ∑[1], ∑[K+1], w, ϵ)
 end
-# gain for Cred
+
+function get_gain(::Type{L}, params::EvoTypes, ∑::AbstractVector{T}) where {L<:Cred,T}
+    ϵ = eps(T)
+    K = (length(∑) - 1) ÷ 2
+    w = ∑[end]
+    g = zero(T)
+    @inbounds for k in 1:K
+        Z = _cred_Z(L, ∑[k], ∑[K+k], w, ϵ)
+        g += Z * abs(∑[k]) / (1 + params.L2 / w)
+    end
+    return g
+end
+
 function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V) where {L<:Cred,T,V<:AbstractVector}
-    Z = _get_cred(L, params, ∑)
-    ZL = _get_cred(L, params, ∑L)
-    ZR = _get_cred(L, params, ∑R)
-    gain = ZL * abs(∑L[1]) / (1 + params.L2 / ∑L[3]) +
-           ZR * abs(∑R[1]) / (1 + params.L2 / ∑R[3]) -
-           Z * abs(∑[1]) / (1 + params.L2 / ∑[3])
+    ϵ = eps(T)
+    K = (length(∑) - 1) ÷ 2
+    w = ∑[end]
+    w_l = ∑L[end]
+    w_r = ∑R[end]
+    gain = zero(T)
+    @inbounds for k in 1:K
+        Z = _cred_Z(L, ∑[k], ∑[K+k], w, ϵ)
+        ZL = _cred_Z(L, ∑L[k], ∑L[K+k], w_l, ϵ)
+        ZR = _cred_Z(L, ∑R[k], ∑R[K+k], w_r, ϵ)
+        gain += ZL * abs(∑L[k]) / (1 + params.L2 / w_l)
+        gain += ZR * abs(∑R[k]) / (1 + params.L2 / w_r)
+        gain -= Z * abs(∑[k]) / (1 + params.L2 / w)
+    end
     return gain
 end

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -34,48 +34,77 @@ const _loss2type_dict = Dict(
 )
 
 # MSE
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{MSE}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds ∇[1, i] = 2 * (p[1, i] - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = 2 * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{MSE}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            ∇[k, i]   = 2 * (p[k, i] - yk) * w
+            ∇[K+k, i] = 2 * w
+        end
     end
 end
 
 # LogLoss - on linear predictor
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{LogLoss}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds pred = sigmoid(p[1, i])
-        @inbounds ∇[1, i] = (pred - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = pred * (1 - pred) * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{LogLoss}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = sigmoid(p[k, i])
+            ∇[k, i]   = (pred - yk) * w
+            ∇[K+k, i] = pred * (1 - pred) * w
+        end
     end
 end
 
 # Poisson
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{Poisson}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds ∇[1, i] = (pred - y[i]) * ∇[3, i]
-        @inbounds ∇[2, i] = pred * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Poisson}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            ∇[k, i]   = (pred - yk) * w
+            ∇[K+k, i] = pred * w
+        end
     end
 end
 
 # Gamma
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{Gamma}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds ∇[1, i] = 2 * (1 - y[i] / pred) * ∇[3, i]
-        @inbounds ∇[2, i] = 2 * y[i] / pred * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Gamma}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            ∇[k, i]   = 2 * (1 - yk / pred) * w
+            ∇[K+k, i] = 2 * yk / pred * w
+        end
     end
 end
 
 # Tweedie
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{Tweedie}, params::EvoTypes) where {T}
-    rho = eltype(p)(1.5)
-    @threads for i in eachindex(y)
-        @inbounds pred = exp(p[1, i])
-        @inbounds ∇[1, i] = 2 * (pred^(2 - rho) - y[i] * pred^(1 - rho)) * ∇[3, i]
-        @inbounds ∇[2, i] =
-            2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * y[i] * pred^(1 - rho)) * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Tweedie}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    rho = T(1.5)
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            ∇[k, i]   = 2 * (pred^(2 - rho) - yk * pred^(1 - rho)) * w
+            ∇[K+k, i] = 2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * yk * pred^(1 - rho)) * w
+        end
     end
 end
 
@@ -204,9 +233,13 @@ function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V)
     ϵ = eps(T)
     lambda = params.lambda
     L2 = params.L2
-    gain = ∑L[1]^2 / max(ϵ, (∑L[2] + lambda * ∑L[3] + L2)) / 2 +
-           ∑R[1]^2 / max(ϵ, (∑R[2] + lambda * ∑R[3] + L2)) / 2 -
-           ∑[1]^2 / max(ϵ, (∑[2] + lambda * ∑[3] + L2)) / 2
+    K = (length(∑) - 1) ÷ 2
+    gain = zero(T)
+    @inbounds for k in 1:K
+        gain += ∑L[k]^2 / max(ϵ, (∑L[k+K] + lambda * ∑L[end] + L2)) / 2
+        gain += ∑R[k]^2 / max(ϵ, (∑R[k+K] + lambda * ∑R[end] + L2)) / 2
+        gain -= ∑[k]^2  / max(ϵ, (∑[k+K]  + lambda * ∑[end]  + L2)) / 2
+    end
     return gain
 end
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -331,13 +331,6 @@ end
     return sqrt(VHM) / (sqrt(VHM) + sqrt(EVPV))
 end
 
-@inline function _get_cred(L::Type{<:Cred}, params::EvoTypes, ∑::AbstractVector{T}) where {T}
-    ϵ = eps(T)
-    K = (length(∑) - 1) ÷ 2
-    w = ∑[end]
-    return _cred_Z(L, ∑[1], ∑[K+1], w, ϵ)
-end
-
 function get_gain(::Type{L}, params::EvoTypes, ∑::AbstractVector{T}) where {L<:Cred,T}
     ϵ = eps(T)
     K = (length(∑) - 1) ÷ 2

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -33,77 +33,44 @@ const _loss2type_dict = Dict(
     :cred_std => CredStd
 )
 
-# MSE
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{MSE}, params::EvoTypes) where {T}
-    K = size(p, 1)
-    w_row = 2 * K + 1
-    @threads for i in axes(p, 2)
-        @inbounds w = ∇[w_row, i]
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            ∇[k, i]   = 2 * (p[k, i] - yk) * w
-            ∇[K+k, i] = 2 * w
-        end
-    end
+@inline _target(y::AbstractVector, k, i) = y[i]
+@inline _target(y::AbstractMatrix, k, i) = y[k, i]
+
+@inline gradreg_grad_hess(::Type{MSE}, pk, yk) = (2 * (pk - yk), 2 * one(pk))
+
+@inline function gradreg_grad_hess(::Type{LogLoss}, pk, yk)
+    pred = sigmoid(pk)
+    return (pred - yk, pred * (1 - pred))
 end
 
-# LogLoss - on linear predictor
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{LogLoss}, params::EvoTypes) where {T}
-    K = size(p, 1)
-    w_row = 2 * K + 1
-    @threads for i in axes(p, 2)
-        @inbounds w = ∇[w_row, i]
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = sigmoid(p[k, i])
-            ∇[k, i]   = (pred - yk) * w
-            ∇[K+k, i] = pred * (1 - pred) * w
-        end
-    end
+@inline function gradreg_grad_hess(::Type{Poisson}, pk, yk)
+    pred = exp(pk)
+    return (pred - yk, pred)
 end
 
-# Poisson
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Poisson}, params::EvoTypes) where {T}
-    K = size(p, 1)
-    w_row = 2 * K + 1
-    @threads for i in axes(p, 2)
-        @inbounds w = ∇[w_row, i]
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            ∇[k, i]   = (pred - yk) * w
-            ∇[K+k, i] = pred * w
-        end
-    end
+@inline function gradreg_grad_hess(::Type{Gamma}, pk, yk)
+    pred = exp(pk)
+    return (2 * (1 - yk / pred), 2 * yk / pred)
 end
 
-# Gamma
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Gamma}, params::EvoTypes) where {T}
-    K = size(p, 1)
-    w_row = 2 * K + 1
-    @threads for i in axes(p, 2)
-        @inbounds w = ∇[w_row, i]
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            ∇[k, i]   = 2 * (1 - yk / pred) * w
-            ∇[K+k, i] = 2 * yk / pred * w
-        end
-    end
+@inline function gradreg_grad_hess(::Type{Tweedie}, pk, yk)
+    rho = oftype(pk, 1.5)
+    pred = exp(pk)
+    return (
+        2 * (pred^(2 - rho) - yk * pred^(1 - rho)),
+        2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * yk * pred^(1 - rho)),
+    )
 end
 
-# Tweedie
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Tweedie}, params::EvoTypes) where {T}
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{L}, params::EvoTypes) where {T,L<:GradientRegression}
     K = size(p, 1)
     w_row = 2 * K + 1
-    rho = T(1.5)
     @threads for i in axes(p, 2)
         @inbounds w = ∇[w_row, i]
         @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            ∇[k, i]   = 2 * (pred^(2 - rho) - yk * pred^(1 - rho)) * w
-            ∇[K+k, i] = 2 * ((2 - rho) * pred^(2 - rho) - (1 - rho) * yk * pred^(1 - rho)) * w
+            g, h = gradreg_grad_hess(L, p[k, i], _target(y, k, i))
+            ∇[k, i] = g * w
+            ∇[K+k, i] = h * w
         end
     end
 end
@@ -129,18 +96,29 @@ function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector, ::Type{MLogLoss}
 end
 
 # MAE
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{MAE}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        @inbounds ∇[1, i] = (y[i] - p[1, i]) * ∇[3, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{MAE}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            ∇[k, i] = (_target(y, k, i) - p[k, i]) * w
+            ∇[K+k, i] = zero(T)
+        end
     end
 end
 
 # Quantile
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{Quantile}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        diff = (y[i] - p[1, i])
-        @inbounds ∇[1, i] = diff > 0 ? params.alpha * ∇[3, i] : (params.alpha - 1) * ∇[3, i]
-        @inbounds ∇[2, i] = diff
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{Quantile}, params::EvoTypes) where {T}
+    K = size(p, 1)
+    w_row = 2 * K + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for k in 1:K
+            diff = _target(y, k, i) - p[k, i]
+            ∇[k, i] = diff > 0 ? params.alpha * w : (params.alpha - 1) * w
+            ∇[K+k, i] = diff
+        end
     end
 end
 
@@ -171,32 +149,27 @@ end
 # Gaussian - http://jrmeyer.github.io/machinelearning/2017/08/18/mle.html
 # pred[i][1] = μ
 # pred[i][2] = log(σ)
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{GaussianMLE}, params::EvoTypes) where {T}
-    Y = size(p, 1) ÷ 2
-    w_row = 4 * Y + 1
-    @threads for i in axes(p, 2)
-        @inbounds w = ∇[w_row, i]
-        @inbounds for t in 1:Y
-            gb = 2 * (t - 1)
-            hb = 2 * Y + 2 * (t - 1)
-            μ = p[2t-1, i]
-            ls = p[2t, i]
-            yt = y isa AbstractVector ? y[i] : y[t, i]
-            inv = 1 / exp(2 * ls)
-            d = μ - yt
-            ∇[gb+1, i] = d * inv * w
-            ∇[gb+2, i] = (1 - d^2 * inv) * w
-            ∇[hb+1, i] = inv * w
-            ∇[hb+2, i] = 2 * inv * d^2 * w
-        end
-    end
+@inline function mle2p_grad_hess(::Type{GaussianMLE}, μ, ls, yt)
+    inv = 1 / exp(2 * ls)
+    d = μ - yt
+    return (d * inv, 1 - d^2 * inv, inv, 2 * inv * d^2)
 end
 
 # LogisticProb - https://en.wikipedia.org/wiki/Logistic_distribution
 # pdf = 
 # pred[i][1] = μ
 # pred[i][2] = log(s)
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{LogisticMLE}, params::EvoTypes) where {T}
+@inline function mle2p_grad_hess(::Type{LogisticMLE}, μ, ls, yt)
+    return (
+        -tanh((yt - μ) / (2 * exp(ls))) * exp(-ls),
+        -(exp(-ls) * (yt - μ) * tanh((yt - μ) / (2 * exp(ls))) - 1),
+        sech((yt - μ) / (2 * exp(ls)))^2 / (2 * exp(2 * ls)),
+        (exp(-2 * ls) * (μ - yt) * (μ - yt + exp(ls) * sinh(exp(-ls) * (μ - yt)))) /
+        (1 + cosh(exp(-ls) * (μ - yt))),
+    )
+end
+
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{L}, params::EvoTypes) where {T,L<:MLE2P}
     Y = size(p, 1) ÷ 2
     w_row = 4 * Y + 1
     @threads for i in axes(p, 2)
@@ -206,13 +179,11 @@ function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type
             hb = 2 * Y + 2 * (t - 1)
             μ = p[2t-1, i]
             ls = p[2t, i]
-            yt = y isa AbstractVector ? y[i] : y[t, i]
-            ∇[gb+1, i] = -tanh((yt - μ) / (2 * exp(ls))) * exp(-ls) * w
-            ∇[gb+2, i] = -(exp(-ls) * (yt - μ) * tanh((yt - μ) / (2 * exp(ls))) - 1) * w
-            ∇[hb+1, i] = sech((yt - μ) / (2 * exp(ls)))^2 / (2 * exp(2 * ls)) * w
-            ∇[hb+2, i] = (exp(-2 * ls) * (μ - yt) *
-                          (μ - yt + exp(ls) * sinh(exp(-ls) * (μ - yt)))) /
-                         (1 + cosh(exp(-ls) * (μ - yt))) * w
+            g1, g2, h1, h2 = mle2p_grad_hess(L, μ, ls, _target(y, t, i))
+            ∇[gb+1, i] = g1 * w
+            ∇[gb+2, i] = g2 * w
+            ∇[hb+1, i] = h1 * w
+            ∇[hb+2, i] = h2 * w
         end
     end
 end
@@ -290,16 +261,34 @@ end
 # MAE
 function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V) where {L<:MAE,T,V<:AbstractVector}
     ϵ = eps(T)
-    gain = abs(∑L[1] / ∑L[3] - ∑[1] / ∑[3]) * ∑L[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑L[3])) +
-           abs(∑R[1] / ∑R[3] - ∑[1] / ∑[3]) * ∑R[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑R[3]))
+    K = (length(∑) - 1) ÷ 2
+    w_p = ∑[end]
+    w_l = ∑L[end]
+    w_r = ∑R[end]
+    d_l = max(ϵ, (1 + params.lambda + params.L2 / w_l))
+    d_r = max(ϵ, (1 + params.lambda + params.L2 / w_r))
+    gain = zero(T)
+    @inbounds for k in 1:K
+        gain += abs(∑L[k] / w_l - ∑[k] / w_p) * w_l / d_l
+        gain += abs(∑R[k] / w_r - ∑[k] / w_p) * w_r / d_r
+    end
     return gain
 end
 
 # Quantile
 function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V) where {L<:Quantile,T,V<:AbstractVector}
     ϵ = eps(T)
-    gain = abs(∑L[1] / ∑L[3] - ∑[1] / ∑[3]) * ∑L[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑L[3])) +
-           abs(∑R[1] / ∑R[3] - ∑[1] / ∑[3]) * ∑R[3] / max(ϵ, (1 + params.lambda + params.L2 / ∑R[3]))
+    K = (length(∑) - 1) ÷ 2
+    w_p = ∑[end]
+    w_l = ∑L[end]
+    w_r = ∑R[end]
+    d_l = max(ϵ, (1 + params.lambda + params.L2 / w_l))
+    d_r = max(ϵ, (1 + params.lambda + params.L2 / w_r))
+    gain = zero(T)
+    @inbounds for k in 1:K
+        gain += abs(∑L[k] / w_l - ∑[k] / w_p) * w_l / d_l
+        gain += abs(∑R[k] / w_r - ∑[k] / w_p) * w_r / d_r
+    end
     return gain
 end
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -171,14 +171,24 @@ end
 # Gaussian - http://jrmeyer.github.io/machinelearning/2017/08/18/mle.html
 # pred[i][1] = μ
 # pred[i][2] = log(σ)
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{GaussianMLE}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        # first order
-        @inbounds ∇[1, i] = (p[1, i] - y[i]) / exp(2 * p[2, i]) * ∇[5, i]
-        @inbounds ∇[2, i] = (1 - (p[1, i] - y[i])^2 / exp(2 * p[2, i])) * ∇[5, i]
-        # second order
-        @inbounds ∇[3, i] = ∇[5, i] / exp(2 * p[2, i])
-        @inbounds ∇[4, i] = ∇[5, i] * 2 / exp(2 * p[2, i]) * (p[1, i] - y[i])^2
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{GaussianMLE}, params::EvoTypes) where {T}
+    Y = size(p, 1) ÷ 2
+    w_row = 4 * Y + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for t in 1:Y
+            gb = 2 * (t - 1)
+            hb = 2 * Y + 2 * (t - 1)
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y isa AbstractVector ? y[i] : y[t, i]
+            inv = 1 / exp(2 * ls)
+            d = μ - yt
+            ∇[gb+1, i] = d * inv * w
+            ∇[gb+2, i] = (1 - d^2 * inv) * w
+            ∇[hb+1, i] = inv * w
+            ∇[hb+2, i] = 2 * inv * d^2 * w
+        end
     end
 end
 
@@ -186,27 +196,24 @@ end
 # pdf = 
 # pred[i][1] = μ
 # pred[i][2] = log(s)
-function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::Vector{T}, ::Type{LogisticMLE}, params::EvoTypes) where {T}
-    @threads for i in eachindex(y)
-        # first order
-        @inbounds ∇[1, i] =
-            -tanh((y[i] - p[1, i]) / (2 * exp(p[2, i]))) * exp(-p[2, i]) * ∇[5, i]
-        @inbounds ∇[2, i] =
-            -(
-                exp(-p[2, i]) *
-                (y[i] - p[1, i]) *
-                tanh((y[i] - p[1, i]) / (2 * exp(p[2, i]))) - 1
-            ) * ∇[5, i]
-        # second order
-        @inbounds ∇[3, i] =
-            sech((y[i] - p[1, i]) / (2 * exp(p[2, i])))^2 / (2 * exp(2 * p[2, i])) *
-            ∇[5, i]
-        @inbounds ∇[4, i] =
-            (
-                exp(-2 * p[2, i]) *
-                (p[1, i] - y[i]) *
-                (p[1, i] - y[i] + exp(p[2, i]) * sinh(exp(-p[2, i]) * (p[1, i] - y[i])))
-            ) / (1 + cosh(exp(-p[2, i]) * (p[1, i] - y[i]))) * ∇[5, i]
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{LogisticMLE}, params::EvoTypes) where {T}
+    Y = size(p, 1) ÷ 2
+    w_row = 4 * Y + 1
+    @threads for i in axes(p, 2)
+        @inbounds w = ∇[w_row, i]
+        @inbounds for t in 1:Y
+            gb = 2 * (t - 1)
+            hb = 2 * Y + 2 * (t - 1)
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y isa AbstractVector ? y[i] : y[t, i]
+            ∇[gb+1, i] = -tanh((yt - μ) / (2 * exp(ls))) * exp(-ls) * w
+            ∇[gb+2, i] = -(exp(-ls) * (yt - μ) * tanh((yt - μ) / (2 * exp(ls))) - 1) * w
+            ∇[hb+1, i] = sech((yt - μ) / (2 * exp(ls)))^2 / (2 * exp(2 * ls)) * w
+            ∇[hb+2, i] = (exp(-2 * ls) * (μ - yt) *
+                          (μ - yt + exp(ls) * sinh(exp(-ls) * (μ - yt)))) /
+                         (1 + cosh(exp(-ls) * (μ - yt))) * w
+        end
     end
 end
 
@@ -248,9 +255,20 @@ function get_gain(::Type{L}, params::EvoTypes, ∑::Vector{T}, ∑L::V, ∑R::V)
     ϵ = eps(T)
     lambda = params.lambda
     L2 = params.L2
-    gain = (∑L[1]^2 / max(ϵ, (∑L[3] + lambda * ∑L[5] + L2)) + ∑L[2]^2 / max(ϵ, (∑L[4] + lambda * ∑L[5] + L2))) / 2 +
-           (∑R[1]^2 / max(ϵ, (∑R[3] + lambda * ∑R[5] + L2)) + ∑R[2]^2 / max(ϵ, (∑R[4] + lambda * ∑R[5] + L2))) / 2 -
-           (∑[1]^2 / max(ϵ, (∑[3] + lambda * ∑[5] + L2)) + ∑[2]^2 / max(ϵ, (∑[4] + lambda * ∑[5] + L2))) / 2
+    Y = (length(∑) - 1) ÷ 4
+    wsum = ∑[end]
+    wsumL = ∑L[end]
+    wsumR = ∑R[end]
+    gain = zero(T)
+    @inbounds for t in 1:Y
+        gb = 2 * (t - 1)
+        hb = 2 * Y + 2 * (t - 1)
+        for s in 1:2
+            gain += ∑L[gb+s]^2 / max(ϵ, (∑L[hb+s] + lambda * wsumL + L2)) / 2
+            gain += ∑R[gb+s]^2 / max(ϵ, (∑R[hb+s] + lambda * wsumR + L2)) / 2
+            gain -= ∑[gb+s]^2 / max(ϵ, (∑[hb+s] + lambda * wsum + L2)) / 2
+        end
+    end
     return gain
 end
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -109,26 +109,42 @@ end
 
 function gaussian_mle(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        eval[i] = -w[i] * (p[2, i] + (y[i] - p[1, i])^2 / (2 * exp(2 * p[2, i])))
+    Y = size(p, 1) ÷ 2
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for t in 1:Y
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y isa AbstractVector ? y[i] : y[t, i]
+            acc += -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+        end
+        eval[i] = w[i] * acc / Y
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
 
 function logistic_mle(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        eval[i] = w[i] * (log(1 / 4 * sech(exp(-p[2, i]) * (y[i] - p[1, i]))^2) - p[2, i])
+    Y = size(p, 1) ÷ 2
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for t in 1:Y
+            μ = p[2t-1, i]
+            ls = p[2t, i]
+            yt = y isa AbstractVector ? y[i] : y[t, i]
+            acc += log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
+        end
+        eval[i] = w[i] * acc / Y
     end
     return sum(Float64, eval) / sum(Float64, w)
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,56 +1,62 @@
-function mse(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T}
+@inline _metric_target(y::AbstractVector, k, i) = y[i]
+@inline _metric_target(y::AbstractMatrix, k, i) = y[k, i]
+
+@inline _metric_value(::Type{MSE}, pk, yk, alpha) = (pk - yk)^2
+@inline _metric_value(::Type{MAE}, pk, yk, alpha) = abs(pk - yk)
+
+@inline function _metric_value(::Type{Quantile}, pk, yk, alpha)
+    return alpha * max(yk - pk, zero(pk)) + (1 - alpha) * max(pk - yk, zero(pk))
+end
+
+@inline function _metric_value(::Type{LogLoss}, pk, yk, alpha)
+    pred = sigmoid(pk)
+    return -yk * log(pred) + (yk - 1) * log(1 - pred)
+end
+
+@inline function _metric_value(::Type{Poisson}, pk, yk, alpha)
+    pred = exp(pk)
+    return 2 * (yk * (log(yk) - log(pred)) + pred - yk)
+end
+
+@inline function _metric_value(::Type{Gamma}, pk, yk, alpha)
+    pred = exp(pk)
+    return 2 * (log(pred / yk) + yk / pred - 1)
+end
+
+@inline function _metric_value(::Type{Tweedie}, pk, yk, alpha)
+    rho = oftype(pk, 1.5)
+    pred = exp(pk)
+    return 2 * (yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) + pred^(2 - rho) / (2 - rho))
+end
+
+function _eval_metric(
+    p::AbstractMatrix{T},
+    y::AbstractVecOrMat{T},
+    w::AbstractVector{T},
+    eval::AbstractVector{T},
+    ::Type{M};
+    alpha=0.5,
+    kwargs...
+) where {T,M}
     K = size(p, 1)
     @threads for i in eachindex(w)
         acc = zero(T)
         @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            acc += (p[k, i] - yk)^2
+            acc += _metric_value(M, p[k, i], _metric_target(y, k, i), alpha)
         end
         eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
+
+mse(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, MSE; kwargs...)
 rmse(p::AbstractMatrix{T}, y::AbstractVecOrMat, w::AbstractVector, eval::AbstractVector; kwargs...) where {T} =
     sqrt(mse(p, y, w, eval::AbstractVector; kwargs...))
-
-function mae(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            acc += abs(p[k, i] - yk)
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
-
-function logloss(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = sigmoid(p[k, i])
-            acc += -yk * log(pred) + (yk - 1) * log(1 - pred)
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
+mae(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, MAE; kwargs...)
+logloss(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, LogLoss; kwargs...)
 
 function mlogloss(
     p::AbstractMatrix{T},
@@ -70,135 +76,41 @@ function mlogloss(
     return sum(Float64, eval) / sum(Float64, w)
 end
 
-function poisson(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            acc += 2 * (yk * (log(yk) - log(pred)) + pred - yk)
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
+poisson(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, Poisson; kwargs...)
+gamma(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, Gamma; kwargs...)
+tweedie(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, Tweedie; kwargs...)
+wmae(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_metric(p, y, w, eval, Quantile; kwargs...)
 
-function gamma(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            acc += 2 * (log(pred / yk) + yk / pred - 1)
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
+@inline _mle2p_metric_value(::Type{GaussianMLE}, μ, ls, yt) = -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+@inline _mle2p_metric_value(::Type{LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
 
-function tweedie(
+function _eval_mle2p_metric(
     p::AbstractMatrix{T},
     y::AbstractVecOrMat{T},
     w::AbstractVector{T},
-    eval::AbstractVector{T};
+    eval::AbstractVector{T},
+    ::Type{M};
     kwargs...
-) where {T}
-    rho = T(1.5)
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            pred = exp(p[k, i])
-            acc +=
-                2 *
-                (
-                    yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) +
-                    pred^(2 - rho) / (2 - rho)
-                )
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
-
-function gaussian_mle(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
+) where {T,M<:MLE2P}
     Y = size(p, 1) ÷ 2
     @threads for i in eachindex(w)
         acc = zero(T)
         @inbounds for t in 1:Y
-            μ = p[2t-1, i]
-            ls = p[2t, i]
-            yt = y isa AbstractVector ? y[i] : y[t, i]
-            acc += -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
+            acc += _mle2p_metric_value(M, p[2t-1, i], p[2t, i], _metric_target(y, t, i))
         end
         eval[i] = w[i] * acc / Y
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
 
-function logistic_mle(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    Y = size(p, 1) ÷ 2
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for t in 1:Y
-            μ = p[2t-1, i]
-            ls = p[2t, i]
-            yt = y isa AbstractVector ? y[i] : y[t, i]
-            acc += log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
-        end
-        eval[i] = w[i] * acc / Y
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
-
-function wmae(
-    p::AbstractMatrix{T},
-    y::AbstractVecOrMat{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    alpha=0.5,
-    kwargs...
-) where {T}
-    K = size(p, 1)
-    @threads for i in eachindex(w)
-        acc = zero(T)
-        @inbounds for k in 1:K
-            yk = y isa AbstractVector ? y[i] : y[k, i]
-            acc +=
-                alpha * max(yk - p[k, i], zero(T)) +
-                (1 - alpha) * max(p[k, i] - yk, zero(T))
-        end
-        eval[i] = w[i] * acc / K
-    end
-    return sum(Float64, eval) / sum(Float64, w)
-end
+gaussian_mle(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_mle2p_metric(p, y, w, eval, GaussianMLE; kwargs...)
+logistic_mle(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T} =
+    _eval_mle2p_metric(p, y, w, eval, LogisticMLE; kwargs...)
 
 function multiquantile(
     p::AbstractMatrix{T},
@@ -215,9 +127,8 @@ function multiquantile(
         wi = w[i]
         acc = zero(T)
         @inbounds for k in 1:K
-            diff = yi - p[k, i]
             alpha = alphas[k]
-            acc += alpha * max(diff, zero(T)) + (1 - alpha) * max(-diff, zero(T))
+            acc += _metric_value(Quantile, p[k, i], yi, alpha)
         end
         eval[i] = wi * acc / K
     end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -10,32 +10,44 @@ function mse(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T},
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
-rmse(p::AbstractMatrix{T}, y::AbstractVector, w::AbstractVector, eval::AbstractVector; kwargs...) where {T} =
+rmse(p::AbstractMatrix{T}, y::AbstractVecOrMat, w::AbstractVector, eval::AbstractVector; kwargs...) where {T} =
     sqrt(mse(p, y, w, eval::AbstractVector; kwargs...))
 
 function mae(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        eval[i] = w[i] * abs(p[1, i] - y[i])
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            acc += abs(p[k, i] - yk)
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
 
 function logloss(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        pred = sigmoid(p[1, i])
-        eval[i] = w[i] * (-y[i] * log(pred) + (y[i] - 1) * log(1 - pred))
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = sigmoid(p[k, i])
+            acc += -yk * log(pred) + (yk - 1) * log(1 - pred)
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
@@ -60,49 +72,66 @@ end
 
 function poisson(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        pred = exp(p[1, i])
-        eval[i] = w[i] * 2 * (y[i] * (log(y[i]) - log(pred)) + pred - y[i])
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            acc += 2 * (yk * (log(yk) - log(pred)) + pred - yk)
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
 
 function gamma(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        pred = exp(p[1, i])
-        eval[i] = w[i] * 2 * (log(pred / y[i]) + y[i] / pred - 1)
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            acc += 2 * (log(pred / yk) + yk / pred - 1)
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
 
 function tweedie(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     kwargs...
 ) where {T}
     rho = T(1.5)
-    @threads for i in eachindex(y)
-        pred = exp(p[1, i])
-        eval[i] =
-            w[i] *
-            2 *
-            (
-                y[i]^(2 - rho) / (1 - rho) / (2 - rho) - y[i] * pred^(1 - rho) / (1 - rho) +
-                pred^(2 - rho) / (2 - rho)
-            )
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            pred = exp(p[k, i])
+            acc +=
+                2 *
+                (
+                    yk^(2 - rho) / (1 - rho) / (2 - rho) - yk * pred^(1 - rho) / (1 - rho) +
+                    pred^(2 - rho) / (2 - rho)
+                )
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end
@@ -151,18 +180,22 @@ end
 
 function wmae(
     p::AbstractMatrix{T},
-    y::AbstractVector{T},
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     alpha=0.5,
     kwargs...
 ) where {T}
-    @threads for i in eachindex(y)
-        eval[i] =
-            w[i] * (
-                alpha * max(y[i] - p[1, i], zero(T)) +
-                (1 - alpha) * max(p[1, i] - y[i], zero(T))
-            )
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            acc +=
+                alpha * max(yk - p[k, i], zero(T)) +
+                (1 - alpha) * max(p[k, i] - yk, zero(T))
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,12 +1,12 @@
-function mse(
-    p::AbstractMatrix{T},
-    y::AbstractVector{T},
-    w::AbstractVector{T},
-    eval::AbstractVector{T};
-    kwargs...
-) where {T}
-    @threads for i in eachindex(y)
-        eval[i] = w[i] * (p[1, i] - y[i])^2
+function mse(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::AbstractVector{T}; kwargs...) where {T}
+    K = size(p, 1)
+    @threads for i in eachindex(w)
+        acc = zero(T)
+        @inbounds for k in 1:K
+            yk = y isa AbstractVector ? y[i] : y[k, i]
+            acc += (p[k, i] - yk)^2
+        end
+        eval[i] = w[i] * acc / K
     end
     return sum(Float64, eval) / sum(Float64, w)
 end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -21,7 +21,9 @@ function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, featty
             cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
             nid = nid << 1 + !cond
         end
-        @inbounds pred[1, i] = clamp(pred[1, i] + tree.pred[1, nid], T(-15), T(15))
+        @inbounds for k in axes(pred, 1)
+            pred[k, i] = clamp(pred[k, i] + tree.pred[k, nid], T(-15), T(15))
+        end
     end
     return nothing
 end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -128,7 +128,10 @@ end
 # GradientRegression predictions
 function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:GradientRegression,T}
     ϵ = eps(T)
-    p[1, n] = -params.eta / params.bagging_size * ∑[1] / max(ϵ, (∑[2] + params.lambda * ∑[3] + params.L2))
+    K = size(p, 1)
+    @inbounds for k in 1:K
+        p[k, n] = -params.eta / params.bagging_size * ∑[k] / max(ϵ, (∑[k+K] + params.lambda * ∑[end] + params.L2))
+    end
 end
 function pred_scalar(∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:GradientRegression,T}
     ϵ = eps(T)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -147,7 +147,11 @@ end
 
 # Cred predictions
 function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:Cred,T}
-    p[1, n] = params.eta / params.bagging_size * ∑[1] / (∑[3] + params.L2)
+    K = size(p, 1)
+    w = ∑[end]
+    @inbounds for k in 1:K
+        p[k, n] = params.eta / params.bagging_size * ∑[k] / (w + params.L2)
+    end
     return nothing
 end
 function pred_scalar(∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:Cred,T}

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -27,6 +27,7 @@ function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, featty
 end
 
 function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L<:MLE2P,K,T}
+    Y = size(pred, 1) ÷ 2
     @threads for i in axes(x_bin, 1)
         nid = 1
         @inbounds while tree.split[nid]
@@ -34,8 +35,10 @@ function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, featty
             cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
             nid = nid << 1 + !cond
         end
-        @inbounds pred[1, i] += tree.pred[1, nid]
-        @inbounds pred[2, i] = max(T(-15), pred[2, i] + tree.pred[2, nid])
+        @inbounds for t in 1:Y
+            pred[2t-1, i] += tree.pred[2t-1, nid]
+            pred[2t, i] = max(T(-15), pred[2t, i] + tree.pred[2t, nid])
+        end
     end
     return nothing
 end
@@ -109,7 +112,7 @@ function _predict(
     elseif L ∈ [Poisson, Gamma, Tweedie]
         pred .= exp.(pred)
     elseif L in [GaussianMLE, LogisticMLE]
-        pred[2, :] .= exp.(pred[2, :])
+        pred[2:2:end, :] .= exp.(pred[2:2:end, :])
     elseif L == MLogLoss
         softmax!(pred)
     end
@@ -152,8 +155,14 @@ end
 # prediction in Leaf - MLE2P
 function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:MLE2P,T}
     ϵ = eps(T)
-    p[1, n] = -params.eta / params.bagging_size * ∑[1] / max(ϵ, (∑[3] + params.lambda * ∑[5] + params.L2))
-    p[2, n] = -params.eta / params.bagging_size * ∑[2] / max(ϵ, (∑[4] + params.lambda * ∑[5] + params.L2))
+    Y = size(p, 1) ÷ 2
+    wsum = ∑[end]
+    @inbounds for t in 1:Y
+        gb = 2 * (t - 1)
+        hb = 2 * Y + 2 * (t - 1)
+        p[2t-1, n] = -params.eta / params.bagging_size * ∑[gb+1] / max(ϵ, (∑[hb+1] + params.lambda * wsum + params.L2))
+        p[2t, n] = -params.eta / params.bagging_size * ∑[gb+2] / max(ϵ, (∑[hb+2] + params.lambda * wsum + params.L2))
+    end
 end
 function pred_scalar(∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:MLE2P,T}
     ϵ = eps(T)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -183,7 +183,12 @@ end
 # MAE
 function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:MAE,T}
     ϵ = eps(T)
-    p[1, n] = params.eta / params.bagging_size * ∑[1] / max(ϵ, (∑[3] + params.lambda * ∑[3] + params.L2))
+    K = size(p, 1)
+    w = ∑[end]
+    denom = max(ϵ, (w + params.lambda * w + params.L2))
+    @inbounds for k in 1:K
+        p[k, n] = params.eta / params.bagging_size * ∑[k] / denom
+    end
 end
 function pred_scalar(∑::AbstractVector{T}, ::Type{L}, params::EvoTypes) where {L<:MAE,T}
     ϵ = eps(T)
@@ -193,7 +198,11 @@ end
 # Quantile
 function pred_leaf_cpu!(p::Matrix, n, ∑::AbstractVector{T}, ::Type{L}, params::EvoTypes, ∇, is) where {L<:Quantile,T}
     ϵ = eps(T)
-    p[1, n] = params.eta / params.bagging_size * quantile(view(∇, 2, is), params.alpha) / (1 + params.lambda + params.L2 / ∑[3])
+    K = size(p, 1)
+    denom = 1 + params.lambda + params.L2 / ∑[end]
+    @inbounds for k in 1:K
+        p[k, n] = params.eta / params.bagging_size * quantile(view(∇, K + k, is), params.alpha) / max(ϵ, denom)
+    end
 end
 
 # MultiQuantile

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -6,7 +6,9 @@ function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, featty
             cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
             nid = nid << 1 + !cond
         end
-        @inbounds pred[1, i] += tree.pred[1, nid]
+        @inbounds for k in axes(pred, 1)
+            pred[k, i] += tree.pred[k, nid]
+        end
     end
     return nothing
 end

--- a/test/multi-target.jl
+++ b/test/multi-target.jl
@@ -1,0 +1,49 @@
+using Test
+using Statistics
+using StatsBase: sample
+using Random
+using DataFrames
+using EvoTrees
+using EvoTrees: fit, predict, sigmoid, logit
+
+@testset "multi-target" begin
+
+    nobs = 10_000
+    Random.seed!(123)
+    x_num = rand(nobs) .* 5
+
+    y = sigmoid(logit(sin.(x_num) .* 0.5 .+ 0.5) + randn(nobs) .* 0.5)
+    dtot = DataFrame(x_num=x_num, y=y)
+    y = sigmoid(logit(sin.(2x_num .- 2) .* 0.5 .+ 0.5) + randn(nobs) .* 0.5)
+    insertcols!(dtot, :y2 => y)
+
+    is = sample(1:nobs, nobs, replace=false)
+    ntr = floor(Int, 0.8 * nobs)
+    dtrain = dtot[is[1:ntr], :]
+    deval  = dtot[is[ntr+1:end], :]
+
+    base = (var(dtrain.y), var(dtrain.y2))
+
+    for loss in [:mse, :logloss, :gamma, :poisson, :tweedie, :mae, :quantile, :cred_std, :cred_var]
+        config = EvoTreeRegressor(; loss, nrounds=200, nbins=64, L2=0.1, gamma=0.05,
+            eta=0.05, max_depth=6, min_weight=1.0, rowsample=0.5, rng=123, device=:cpu)
+        model = fit(config, dtrain; feature_names=["x_num"], target_name=["y", "y2"], deval, verbosity=0)
+        pred = model(dtrain; device=:cpu)
+
+        @test size(pred, 2) == 2
+        @test all(isfinite, pred)
+        @test mean((pred[:, 1] .- dtrain.y).^2)  < base[1] * 0.9
+        @test mean((pred[:, 2] .- dtrain.y2).^2) < base[2] * 0.9
+    end
+
+    # gaussian MLE: (μ, logσ) per target → 4 columns, means at 1 and 3
+    config = EvoTreeMLE(; loss=:gaussian_mle, nrounds=200, nbins=64, L2=0.1, gamma=0.05,
+        eta=0.05, max_depth=6, min_weight=1.0, rowsample=0.5, rng=123, device=:cpu)
+    model = fit(config, dtrain; feature_names=["x_num"], target_name=["y", "y2"], verbosity=0)
+    pred = model(dtrain; device=:cpu)
+
+    @test size(pred, 2) == 4
+    @test all(isfinite, pred)
+    @test mean((pred[:, 1] .- dtrain.y).^2)  < base[1] * 0.9
+    @test mean((pred[:, 3] .- dtrain.y2).^2) < base[2] * 0.9
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Test
         include("tables.jl")
         include("monotonic.jl")
         include("missings.jl")
+        include("multi-target.jl")
     end
 
     @testset "MLJ" begin


### PR DESCRIPTION
Add multi-target regression (`:mtmse`): joint vector-target fitting on CPU + GPU.
Fits one tree model to multiple targets jointly with shared structure, vector leaf, and split gain summed over targets. Use via `loss=:mtmse` with `target_name=[:y1, :y2, :y3]` (or a `(K, nobs)` matrix); predictions return `(nobs, K)`.
 
Implemented as K = n_targets stacked into the existing `2K+1` histogram axis with a single shared weight row, not a separate 5D dimension. Reuses the already-K-generic histogram and split kernels unchanged and stores weight once