### PR TITLE
Add early_stopping_tolerance parameter for early stopping

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -123,11 +123,12 @@ function (cb::CallBack)(logger, iter, tree)
     return nothing
 end
 
-function init_logger(; metric, maximise, early_stopping_rounds)
+function init_logger(; metric, maximise, early_stopping_rounds, early_stopping_tolerance=0.0)
     logger = Dict(
         :name => String(metric),
         :maximise => maximise,
         :early_stopping_rounds => early_stopping_rounds,
+        :early_stopping_tolerance => early_stopping_tolerance,
         :nrounds => 0,
         :iter => Int[],
         :metrics => Float64[],
@@ -145,8 +146,10 @@ function update_logger!(logger, iter, metric)
     if iter == 0
         logger[:best_metric] = metric
     else
-        if (logger[:maximise] && metric > logger[:best_metric]) ||
-           (!logger[:maximise] && metric < logger[:best_metric])
+        tol = logger[:early_stopping_tolerance]
+        improved = logger[:maximise] ? (metric > logger[:best_metric] + tol) :
+                                       (metric < logger[:best_metric] - tol)
+        if improved
             logger[:best_metric] = metric
             logger[:best_iter] = iter
             logger[:iter_since_best] = 0

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -328,7 +328,7 @@ function fit(
     if !isnothing(deval)
         deval = Tables.columntable(deval)
         cb = CallBack(params, m, deval, _device; target_name, weight_name, offset_name)
-        logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds)
+        logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds, params.early_stopping_tolerance)
         cb(logger, 0, m.trees[end])
         (verbosity > 0) && @info "initialization" metric = logger[:metrics][end]
     else
@@ -420,7 +420,7 @@ function fit(
     end
     if logging_flag
         cb = CallBack(params, m, x_eval, y_eval, _device; w_eval, offset_eval)
-        logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds)
+        logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds, params.early_stopping_tolerance)
         cb(logger, 0, m.trees[end])
         (verbosity > 0) && @info "initialization" metric = logger[:metrics][end]
     else

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -4,6 +4,7 @@ mutable struct EvoTreeRegressor <: MMI.Deterministic
     nrounds::Int
     bagging_size::Int
     early_stopping_rounds::Int
+    early_stopping_tolerance::Float64
     L2::Float64
     lambda::Float64
     gamma::Float64
@@ -30,6 +31,7 @@ function EvoTreeRegressor(; kwargs...)
         :nrounds => 100,
         :bagging_size => 1,
         :early_stopping_rounds => typemax(Int),
+        :early_stopping_tolerance => 0.0,
         :L2 => 1.0,
         :lambda => 0.0,
         :gamma => 0.0,
@@ -95,6 +97,7 @@ function EvoTreeRegressor(; kwargs...)
         args[:nrounds],
         args[:bagging_size],
         args[:early_stopping_rounds],
+        args[:early_stopping_tolerance],
         args[:L2],
         args[:lambda],
         args[:gamma],
@@ -121,6 +124,7 @@ mutable struct EvoTreeCount <: MMI.Probabilistic
     nrounds::Int
     bagging_size::Int
     early_stopping_rounds::Int
+    early_stopping_tolerance::Float64
     L2::Float64
     lambda::Float64
     gamma::Float64
@@ -143,6 +147,7 @@ function EvoTreeCount(; kwargs...)
         :nrounds => 100,
         :bagging_size => 1,
         :early_stopping_rounds => typemax(Int),
+        :early_stopping_tolerance => 0.0,
         :L2 => 1.0,
         :lambda => 0.0,
         :gamma => 0.0,
@@ -180,6 +185,7 @@ function EvoTreeCount(; kwargs...)
         args[:nrounds],
         args[:bagging_size],
         args[:early_stopping_rounds],
+        args[:early_stopping_tolerance],
         args[:L2],
         args[:lambda],
         args[:gamma],
@@ -204,6 +210,7 @@ mutable struct EvoTreeClassifier <: MMI.Probabilistic
     nrounds::Int
     bagging_size::Int
     early_stopping_rounds::Int
+    early_stopping_tolerance::Float64
     L2::Float64
     lambda::Float64
     gamma::Float64
@@ -225,6 +232,7 @@ function EvoTreeClassifier(; kwargs...)
         :nrounds => 100,
         :bagging_size => 1,
         :early_stopping_rounds => typemax(Int),
+        :early_stopping_tolerance => 0.0,
         :L2 => 1.0,
         :lambda => 0.0,
         :gamma => 0.0,
@@ -261,6 +269,7 @@ function EvoTreeClassifier(; kwargs...)
         args[:nrounds],
         args[:bagging_size],
         args[:early_stopping_rounds],
+        args[:early_stopping_tolerance],
         args[:L2],
         args[:lambda],
         args[:gamma],
@@ -284,6 +293,7 @@ mutable struct EvoTreeMLE <: MMI.Probabilistic
     nrounds::Int
     bagging_size::Int
     early_stopping_rounds::Int
+    early_stopping_tolerance::Float64
     L2::Float64
     lambda::Float64
     gamma::Float64
@@ -308,6 +318,7 @@ function EvoTreeMLE(; kwargs...)
         :nrounds => 100,
         :bagging_size => 1,
         :early_stopping_rounds => typemax(Int),
+        :early_stopping_tolerance => 0.0,
         :L2 => 1.0,
         :lambda => 0.0,
         :gamma => 0.0,
@@ -356,6 +367,7 @@ function EvoTreeMLE(; kwargs...)
         args[:nrounds],
         args[:bagging_size],
         args[:early_stopping_rounds],
+        args[:early_stopping_tolerance],
         args[:L2],
         args[:lambda],
         args[:gamma],
@@ -380,6 +392,7 @@ mutable struct EvoTreeGaussian <: MMI.Probabilistic
     nrounds::Int
     bagging_size::Int
     early_stopping_rounds::Int
+    early_stopping_tolerance::Float64
     L2::Float64
     lambda::Float64
     gamma::Float64
@@ -401,6 +414,7 @@ function EvoTreeGaussian(; kwargs...)
         :nrounds => 100,
         :bagging_size => 1,
         :early_stopping_rounds => typemax(Int),
+        :early_stopping_tolerance => 0.0,
         :L2 => 1.0,
         :lambda => 0.0,
         :gamma => 0.0,
@@ -438,6 +452,7 @@ function EvoTreeGaussian(; kwargs...)
         args[:nrounds],
         args[:bagging_size],
         args[:early_stopping_rounds],
+        args[:early_stopping_tolerance],
         args[:L2],
         args[:lambda],
         args[:gamma],
@@ -509,6 +524,7 @@ function check_args(args::Dict{Symbol,Any})
     check_parameter(Float64, args[:lambda], zero(Float64), typemax(Float64), :lambda)
     check_parameter(Float64, args[:gamma], zero(Float64), typemax(Float64), :gamma)
     check_parameter(Float64, args[:min_weight], zero(Float64), typemax(Float64), :min_weight)
+    check_parameter(Float64, args[:early_stopping_tolerance], zero(Float64), typemax(Float64), :early_stopping_tolerance)
 
     # check bounded parameters
     check_parameter(Float64, args[:rowsample], eps(Float64), one(Float64), :rowsample)
@@ -546,6 +562,7 @@ function check_args(model::EvoTypes)
     check_parameter(Float64, model.lambda, zero(Float64), typemax(Float64), :lambda)
     check_parameter(Float64, model.gamma, zero(Float64), typemax(Float64), :gamma)
     check_parameter(Float64, model.min_weight, zero(Float64), typemax(Float64), :min_weight)
+    check_parameter(Float64, model.early_stopping_tolerance, zero(Float64), typemax(Float64), :early_stopping_tolerance)
 
     # check bounded parameters
     check_parameter(Float64, model.rowsample, eps(Float64), one(Float64), :rowsample)

--- a/test/core.jl
+++ b/test/core.jl
@@ -56,6 +56,52 @@ y_train, y_eval = Y[i_train], Y[i_eval]
     @test mse_gain_pct < -0.75
 end
 
+@testset "EvoTreeRegressor - MSE early stopping tolerance" begin
+    seed!(321)
+    n = 1_000
+    x = randn(n, 1)
+    y = x[:, 1] .+ 0.1 .* randn(n)
+    idx = sample(1:n, n, replace=false)
+    n_train = floor(Int, 0.8 * n)
+    x_train_es, y_train_es = x[idx[1:n_train], :], y[idx[1:n_train]]
+    x_eval_es, y_eval_es = x[idx[n_train+1:end], :], y[idx[n_train+1:end]]
+
+    params_strict = EvoTreeRegressor(
+        loss=:mse,
+        nrounds=50,
+        early_stopping_rounds=5,
+        early_stopping_tolerance=0.0,
+        eta=0.05,
+        seed=123,
+    )
+    params_tolerant = EvoTreeRegressor(
+        loss=:mse,
+        nrounds=50,
+        early_stopping_rounds=5,
+        early_stopping_tolerance=0.01,
+        eta=0.05,
+        seed=123,
+    )
+
+    m_strict = fit(params_strict; x_train=x_train_es, y_train=y_train_es, x_eval=x_eval_es, y_eval=y_eval_es, verbosity=0)
+    m_tolerant = fit(params_tolerant; x_train=x_train_es, y_train=y_train_es, x_eval=x_eval_es, y_eval=y_eval_es, verbosity=0)
+    m_default = fit(
+        EvoTreeRegressor(loss=:mse, nrounds=50, early_stopping_rounds=5, eta=0.05, seed=123);
+        x_train=x_train_es,
+        y_train=y_train_es,
+        x_eval=x_eval_es,
+        y_eval=y_eval_es,
+        verbosity=0,
+    )
+
+    @test length(m_tolerant.trees) < length(m_strict.trees)
+    @test length(m_strict.trees) == params_strict.nrounds + 1
+    @test m_tolerant.info[:logger][:iter_since_best] >= params_tolerant.early_stopping_rounds
+    @test m_tolerant.info[:logger][:best_iter] < m_strict.info[:logger][:best_iter]
+    @test length(m_default.trees) == length(m_strict.trees)
+    @test predict(m_default, x_eval_es) == predict(m_strict, x_eval_es)
+end
+
 @testset "EvoTreeRegressor - logloss" begin
     params1 = EvoTreeRegressor(
         loss=:logloss,


### PR DESCRIPTION
Adds an `early_stopping_tolerance` parameter so that improvements smaller than the tolerance no longer reset the early-stopping counter.
PR to address #329 