### PR TITLE
Add predict_leaf_idx for leaf index extraction

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,6 +10,7 @@ EvoTrees.fit
 
 ```@docs
 EvoTrees.predict
+EvoTrees.predict_leaf_idx
 ```
 
 ## SHAP

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -122,6 +122,55 @@ function _predict(
     return pred
 end
 
+function predict_leaf_idx!(
+    leaf_idx::AbstractVector,
+    tree::Tree{L,K},
+    x_bin::Matrix{UInt8},
+    feattypes::Vector{Bool},
+) where {L,K}
+    @threads for i in axes(x_bin, 1)
+        nid = 1
+        @inbounds while tree.split[nid]
+            feat = tree.feat[nid]
+            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
+            nid = nid << 1 + !cond
+        end
+        @inbounds leaf_idx[i] = nid
+    end
+    return nothing
+end
+
+"""
+    predict_leaf_idx(m::EvoTree, data; ntree_limit=length(m.trees))
+
+Return the index of the leaf into which each observation falls, for each tree of the model.
+
+The result is a `Matrix{UInt32}` of size `(nobs, ntree_limit)`, where `[i, j]` is the index of
+the leaf reached by observation `i` in tree `j`. Indices refer to the node numbering of
+`m.trees[j]`: the root is `1`, and the children of node `n` are `2n` and `2n + 1`.
+Use `ntree_limit=N` to only use the first `N` trees.
+
+Leaf indices are a categorical encoding of the partition of the feature space learned by the
+model, and can be used as features for a downstream model.
+
+```julia
+leaf_idx = EvoTrees.predict_leaf_idx(m, x)
+```
+"""
+function predict_leaf_idx(m::EvoTree, data; ntree_limit=length(m.trees))
+    Tables.istable(data) ? data = Tables.columntable(data) : nothing
+    ntrees = length(m.trees)
+    ntree_limit > ntrees && error("ntree_limit is larger than number of trees $ntrees.")
+    x_bin = binarize(data; feature_names=m.info[:feature_names], edges=m.info[:edges])
+    nobs = size(x_bin, 1)
+    leaf_idx = zeros(UInt32, nobs, ntree_limit)
+    feattypes = m.info[:feattypes]
+    for j = 1:ntree_limit
+        predict_leaf_idx!(view(leaf_idx, :, j), m.trees[j], x_bin, feattypes)
+    end
+    return leaf_idx
+end
+
 function softmax!(p::AbstractMatrix)
     @threads for i in axes(p, 2)
         _p = view(p, :, i)

--- a/test/predict-leaf-idx.jl
+++ b/test/predict-leaf-idx.jl
@@ -1,0 +1,88 @@
+using Test
+using Statistics
+using Random
+using EvoTrees
+using EvoTrees: fit, predict, predict_leaf_idx
+
+@testset "predict_leaf_idx" begin
+
+    nobs = 1_000
+    nfeats = 5
+    Random.seed!(123)
+    x = rand(nobs, nfeats)
+    y = x[:, 1] .* 2 .+ sin.(x[:, 2] .* 5) .+ 0.1 .* randn(nobs)
+
+    config = EvoTreeRegressor(nrounds=10, max_depth=4, eta=0.2)
+    m = fit(config; x_train=x, y_train=y)
+
+    leaf_idx = predict_leaf_idx(m, x)
+
+    @testset "shape and type" begin
+        @test size(leaf_idx) == (nobs, length(m.trees))
+        @test eltype(leaf_idx) == UInt32
+    end
+
+    @testset "indices point to actual leaves" begin
+        for (j, tree) in enumerate(m.trees)
+            idx = leaf_idx[:, j]
+            @test all(1 .<= idx .<= length(tree.split))
+            # A returned node must be a leaf, never an internal split node.
+            @test !any(tree.split[i] for i in idx)
+        end
+    end
+
+    @testset "agrees with an independent traversal" begin
+        feattypes = m.info[:feattypes]
+        x_bin = EvoTrees.binarize(x; feature_names=m.info[:feature_names], edges=m.info[:edges])
+        for (j, tree) in enumerate(m.trees)
+            for i in (1, 7, 123, nobs)
+                nid = 1
+                while tree.split[nid]
+                    feat = tree.feat[nid]
+                    cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] :
+                           x_bin[i, feat] == tree.cond_bin[nid]
+                    nid = nid << 1 + !cond
+                end
+                @test leaf_idx[i, j] == nid
+            end
+        end
+    end
+
+    @testset "consistent with predict" begin
+        # Observations reaching the same leaf of every tree must receive the same prediction.
+        p = predict(m, x)
+        groups = Dict{Vector{UInt32},Vector{Int}}()
+        for i in 1:nobs
+            push!(get!(groups, leaf_idx[i, :], Int[]), i)
+        end
+        @test length(groups) > 1
+        for is in values(groups)
+            @test all(p[is] .≈ p[is[1]])
+        end
+    end
+
+    @testset "ntree_limit" begin
+        @test size(predict_leaf_idx(m, x; ntree_limit=3)) == (nobs, 3)
+        @test predict_leaf_idx(m, x; ntree_limit=3) == leaf_idx[:, 1:3]
+        @test_throws ErrorException predict_leaf_idx(m, x; ntree_limit=length(m.trees) + 1)
+    end
+
+    @testset "stump has a single leaf" begin
+        m1 = fit(EvoTreeRegressor(nrounds=3, max_depth=1); x_train=x, y_train=y)
+        @test all(predict_leaf_idx(m1, x) .== 1)
+    end
+
+    @testset "tables input" begin
+        feature_names = ["x$j" for j in 1:nfeats]
+        dtrain = (; (Symbol("x$j") => x[:, j] for j in 1:nfeats)..., y=y)
+        m_nt = fit(
+            EvoTreeRegressor(nrounds=10, max_depth=4, eta=0.2),
+            dtrain;
+            target_name="y", feature_names,
+        )
+        idx_nt = predict_leaf_idx(m_nt, dtrain)
+        @test size(idx_nt) == (nobs, length(m_nt.trees))
+        # A table and the equivalent matrix must yield identical leaf assignments.
+        @test idx_nt == leaf_idx
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Test
 
     @testset "Internal API" begin
         include("core.jl")
+        include("predict-leaf-idx.jl")
         include("oblivious.jl")
         include("tables.jl")
         include("monotonic.jl")


### PR DESCRIPTION
Adds `EvoTrees.predict_leaf_idx(m, data; ntree_limit)`, returning a `Matrix{UInt32}` of size `(nobs, ntree_limit)` where `[i, j]` is the index of the leaf reached by observation `i` in tree `j`. Node indices follow the existing numbering: root is `1`, children of `n` are `2n` and `2n + 1`.
PR to address #330

Reuses the descent already in `predict!`, but records `nid` instead of accumulating `tree.pred`. The traversal only reads `tree.split`, `tree.feat`, `tree.cond_bin` and `feattypes`, so it is loss independent and a single generic method covers all model types rather than one per loss. No existing code paths are modified, and `predict_leaf_idx` is left unexported to match `predict` and `fit`.

Tests in `test/predict-leaf-idx.jl` cover shape and type, that every returned index is a leaf and in bounds, agreement with an independent traversal against the tree fields, consistency with `predict` (observations sharing a leaf in every tree get identical predictions), `ntree_limit` truncation and its error path, a `max_depth=1` stump, and table input matching the equivalent matrix. Docstring registered under Public API > Predict in `docs/src/api.md`.
