### PR TITLE
Fix gini metric: relax gini_raw signature and correct argument order

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -136,7 +136,7 @@ function multiquantile(
 end
 
 
-function gini_raw(p::V, y::V) where {V<:AbstractVector}
+function gini_raw(p::AbstractVector, y::AbstractVector)
     _y = y .- minimum(y)
     if length(_y) < 2
         return 0.0
@@ -152,7 +152,7 @@ function gini_norm(p::AbstractVector, y::AbstractVector)
     if length(y) < 2
         return 0.0
     end
-    return gini_raw(y, p) / gini_raw(y, y)
+    return gini_raw(p, y) / gini_raw(y, y)
 end
 
 function gini(

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -1,0 +1,68 @@
+using Test
+using Statistics
+using Random
+using EvoTrees
+using EvoTrees: fit, predict, gini_raw, gini_norm
+
+@testset "metrics" begin
+
+    @testset "gini_norm" begin
+
+        nobs = 1_000
+        Random.seed!(123)
+        y = rand(nobs)
+
+        # `gini` passes a view over the prediction matrix, which is not the same concrete
+        # type as `y`. This must not throw.
+        p = reshape(copy(y), 1, :)
+        w = ones(nobs)
+        @test EvoTrees.gini(p, y, w, Float64[]) ≈ 1.0
+
+        # A strictly monotone transform of the target ranks observations perfectly, so the
+        # normalized gini is 1 regardless of the prediction's scale or offset.
+        @test gini_norm(y, y) ≈ 1.0
+        @test gini_norm(2 .* y .+ 10, y) ≈ 1.0
+        @test gini_norm(exp.(y), y) ≈ 1.0
+
+        # Only the ordering of the predictions matters.
+        p_noisy = y .+ 0.1 .* randn(nobs)
+        @test gini_norm(p_noisy, y) ≈ gini_norm(3 .* p_noisy .+ 5, y)
+
+        # An uninformative prediction carries no ranking information.
+        @test abs(gini_norm(rand(nobs), y)) < 0.1
+
+        # A reversed ranking is the negative of a perfect one.
+        @test gini_norm(-y, y) ≈ -1.0
+
+        # Predictions are the first argument: the function is not symmetric.
+        @test gini_norm(p_noisy, y) != gini_norm(y, p_noisy)
+
+        # A better ranking scores higher than a worse one.
+        @test gini_norm(p_noisy, y) > gini_norm(y .+ 1.0 .* randn(nobs), y)
+
+        @test gini_norm([1.0], [1.0]) == 0.0
+    end
+
+    @testset "gini as eval metric" begin
+
+        nobs = 1_000
+        Random.seed!(123)
+        x = rand(nobs, 5)
+        y = x[:, 1] .* 2 .+ 0.1 .* randn(nobs)
+
+        config = EvoTreeRegressor(nrounds=20, eta=0.2, metric=:gini)
+        m = fit(
+            config;
+            x_train=x, y_train=y,
+            x_eval=x, y_eval=y,
+            print_every_n=1_000,
+        )
+
+        # Training must run to completion: a metric that throws, or one that never
+        # improves, would error or stop early.
+        @test m.info[:nrounds] == 20
+
+        p = predict(m, x)
+        @test gini_norm(p, y) > 0.8
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
     @testset "Internal API" begin
         include("core.jl")
         include("predict-leaf-idx.jl")
+        include("metrics.jl")
         include("oblivious.jl")
         include("tables.jl")
         include("monotonic.jl")


### PR DESCRIPTION
`metric=:gini` throws on every call:

```
MethodError: no method matching gini_raw(::Vector{Float64}, ::SubArray{Float64, 1, Matrix{Float64}, ...})
```

There are two separate issues. `gini_raw` constrains both of its arguments to the same concrete type, but `gini` passes a view over the prediction matrix alongside a plain vector, so the call never resolves. Separately, `gini_norm` calls `gini_raw(y, p)` while `gini_raw` sorts by its first argument, so the ranking is taken from the target rather than from the prediction.

Both are fixed by matching the implementation in Evovest/MLBenchmarks.jl `src/Metrics.jl`, which has `gini_raw(p::AbstractVector, y::AbstractVector)` and `gini_raw(p, y) / gini_raw(y, y)`. The signature is also the one used here before f9210c7.

Adds `test/metrics.jl` covering the view/vector call, invariance of the normalized gini to monotone transforms of the prediction, the reversed-ranking and uninformative-prediction cases, argument order, and `metric=:gini` running end to end through `fit`. On current `main` that file produces two errors and two failures, one of the errors being `fit(...; metric=:gini)` itself.
