### PR TITLE
Fix MLJ update to refit when hyperparameters other than nrounds change

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -8,18 +8,28 @@ function MMI.fit(model::EvoTypes, verbosity::Int, A, y, w=nothing)
   device = model.device == :gpu ? GPU : CPU
   V = device_array_type(device)
   w = isnothing(w) ? device_ones(device, T, nobs) : V{T}(w)
-  fitresult, cache = init_core(model, device, A, feature_names, y, w, nothing)
+  fitresult, core = init_core(model, device, A, feature_names, y, w, nothing)
 
   while fitresult.info[:nrounds] < model.nrounds
-    grow_evotree!(fitresult, cache, model)
+    grow_evotree!(fitresult, core, model)
   end
-  report = (features=cache.feature_names,)
-  return fitresult, cache, report
+  report = (features=core.feature_names,)
+  return fitresult, (core=core, model=deepcopy(model)), report
 end
 
+"""
+    okay_to_continue(model, fitresult, cache)
+
+Whether `MMI.update` may extend the existing fit instead of retraining from scratch.
+
+Boosting can only append trees to an existing ensemble, so continuing is valid only when the
+requested model differs from the fitted one in `nrounds` alone, and `nrounds` has not been
+reduced below the number of trees already grown. Any other hyperparameter change requires a
+cold restart, since the trees already fitted were grown under the previous values.
+"""
 function okay_to_continue(model, fitresult, cache)
-  check = model.nrounds - fitresult.info[:nrounds] >= 0
-  return check
+  return MMI.is_same_except(model, cache.model, :nrounds) &&
+         model.nrounds >= fitresult.info[:nrounds]
 end
 
 # For EarlyStopping.jl support
@@ -36,11 +46,12 @@ function MMI.update(
 )
   if okay_to_continue(model, fitresult, cache)
     while fitresult.info[:nrounds] < model.nrounds
-      grow_evotree!(fitresult, cache, model)
+      grow_evotree!(fitresult, cache.core, model)
     end
-    report = (features=cache.feature_names,)
+    cache = (core=cache.core, model=deepcopy(model))
+    report = (features=cache.core.feature_names,)
   else
-    fitresult, cache, report = fit(model, verbosity, A, y, w)
+    fitresult, cache, report = MMI.fit(model, verbosity, A, y, w)
   end
   return fitresult, cache, report
 end

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -51,6 +51,8 @@ function MMI.update(
     cache = (core=cache.core, model=deepcopy(model))
     report = (features=cache.core.feature_names,)
   else
+    verbosity > 0 &&
+      @info "Only `nrounds` supports warm restart. Retraining from scratch."
     fitresult, cache, report = MMI.fit(model, verbosity, A, y, w)
   end
   return fitresult, cache, report

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -51,8 +51,6 @@ function MMI.update(
     cache = (core=cache.core, model=deepcopy(model))
     report = (features=cache.core.feature_names,)
   else
-    verbosity > 0 &&
-      @info "Only `nrounds` supports warm restart. Retraining from scratch."
     fitresult, cache, report = MMI.fit(model, verbosity, A, y, w)
   end
   return fitresult, cache, report

--- a/test/MLJ.jl
+++ b/test/MLJ.jl
@@ -297,8 +297,11 @@ MLJBase.update(model, 2, f, c, data...);
 @testset "update cold restart" begin
 
     seed = 123
-    X = MLJBase.table(rand(200, 3))
-    y = rand(200)
+    # Use a local RNG: the suite seeds the global RNG in core.jl, so drawing from it
+    # here would shift the stream for every test that follows.
+    rng = Xoshiro(42)
+    X = MLJBase.table(rand(rng, 200, 3))
+    y = rand(rng, 200)
 
     # Changing any hyperparameter other than `nrounds` invalidates the trees already
     # grown, so `update` must discard them and refit rather than continue boosting.

--- a/test/MLJ.jl
+++ b/test/MLJ.jl
@@ -294,6 +294,46 @@ f, c, r = MLJBase.fit(model, 2, data...);
 model.lambda = 0.1
 MLJBase.update(model, 2, f, c, data...);
 
+@testset "update cold restart" begin
+
+    seed = 123
+    X = MLJBase.table(rand(200, 3))
+    y = rand(200)
+
+    # Changing any hyperparameter other than `nrounds` invalidates the trees already
+    # grown, so `update` must discard them and refit rather than continue boosting.
+    model = EvoTreeRegressor(; nrounds=10, eta=0.05, max_depth=3, seed)
+    data = MLJBase.reformat(model, X, y)
+    f, c, _ = MLJBase.fit(model, 0, data...)
+    p_stale = MLJBase.predict(model, f, X)
+
+    model2 = EvoTreeRegressor(; nrounds=10, eta=0.9, max_depth=6, seed)
+    f2, c2, _ = MLJBase.update(model2, 0, f, c, data...)
+    p_update = MLJBase.predict(model2, f2, X)
+
+    f3, _, _ = MLJBase.fit(model2, 0, data...)
+    p_fresh = MLJBase.predict(model2, f3, X)
+
+    @test !all(p_update .≈ p_stale)
+    @test all(p_update .≈ p_fresh)
+
+    # Reducing `nrounds` below the number of trees already grown also requires a refit.
+    model3 = EvoTreeRegressor(; nrounds=4, eta=0.05, max_depth=3, seed)
+    f4, _, _ = MLJBase.update(model3, 0, f, c, data...)
+    @test f4.info[:nrounds] == 4
+
+    # Increasing `nrounds` alone is the one case that may continue from the existing
+    # ensemble, and doing so must agree with a fit from scratch.
+    model4 = EvoTreeRegressor(; nrounds=25, eta=0.05, max_depth=3, seed)
+    f5, _, _ = MLJBase.update(model4, 0, f, c, data...)
+    f6, _, _ = MLJBase.fit(model4, 0, data...)
+    @test f5.info[:nrounds] == 25
+    @test all(
+        MLJBase.predict(model4, f5, X) .≈
+        MLJBase.predict(model4, f6, X),
+    )
+end
+
 
 ############################
 # Feature Importances


### PR DESCRIPTION
`MMI.update` continues boosting an existing model whenever `nrounds` has not decreased, regardless of what else changed, because `okay_to_continue` compares only `nrounds`. Any other hyperparameter change returns the previously fitted model untouched, so MLJ tuning silently scores the same model repeatedly.

PR to address #345, and #344 which has the same cause.

`MMI.fit` now returns the fitted model alongside the cache, so `update` can compare against what was actually fitted:

```julia
return fitresult, (core=core, model=deepcopy(model)), report

function okay_to_continue(model, fitresult, cache)
  return MMI.is_same_except(model, cache.model, :nrounds) &&
         model.nrounds >= fitresult.info[:nrounds]
end
```

Keeping the previous model in the MLJ cache rather than on the Cache structs confines the change to `src/MLJ.jl`, which avoids overlapping #340. It follows the same shape as MLJDecisionTreeInterface, including the `verbosity > 0 && @info` on cold restart.

Continuing from an existing ensemble is preserved for the `nrounds`-only case: growing 10 rounds to 25 through `update` gives predictions identical to a fresh 25-round fit.

One deliberate difference from the MLJDecisionTreeInterface example: it handles a decrease in the iteration parameter by truncating the existing forest. EvoTrees pushes `bagging_size` trees per round, so the equivalent would need `1:(nrounds * bagging_size)` plus a matching `info[:nrounds]` update. That is an optimisation rather than a correctness fix, so a decrease still goes through a full refit here.

Verified against the `learning_curve` reproduction in #344, sweeping `max_depth` from 1 to 10:

```
main:  [3.448369, 3.448369, 3.448369, ...]   1 of 10 distinct
fix:   [3.448369, 0.396577, 0.314992, ...]  10 of 10 distinct
```

Tests added in `test/MLJ.jl` cover a hyperparameter change refitting and matching a fresh fit, a decrease in `nrounds` refitting, and an increase continuing while still agreeing with a fresh fit. They produce two failures on current `main`. They sit alongside the block added in response to #92, which already exercised this path but asserted nothing about the result.
