### PR TITLE
Fix logistic_mle eval metric to match the logistic log-density

### DIFF
--- a/ext/EvoTreesCUDAExt/metrics.jl
+++ b/ext/EvoTreesCUDAExt/metrics.jl
@@ -28,7 +28,7 @@ end
 end
 
 @inline _mle2p_metric_value(::Type{EvoTrees.GaussianMLE}, μ, ls, yt) = -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
-@inline _mle2p_metric_value(::Type{EvoTrees.LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
+@inline _mle2p_metric_value(::Type{EvoTrees.LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ) / 2)^2) - ls
 
 ########################
 # Pointwise metrics

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -86,7 +86,7 @@ wmae(p::AbstractMatrix{T}, y::AbstractVecOrMat{T}, w::AbstractVector{T}, eval::A
     _eval_metric(p, y, w, eval, Quantile; kwargs...)
 
 @inline _mle2p_metric_value(::Type{GaussianMLE}, μ, ls, yt) = -(ls + (yt - μ)^2 / (2 * exp(2 * ls)))
-@inline _mle2p_metric_value(::Type{LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ))^2) - ls
+@inline _mle2p_metric_value(::Type{LogisticMLE}, μ, ls, yt) = log(1 / 4 * sech(exp(-ls) * (yt - μ) / 2)^2) - ls
 
 function _eval_mle2p_metric(
     p::AbstractMatrix{T},

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -65,4 +65,36 @@ using EvoTrees: fit, predict, gini_raw, gini_norm
         p = predict(m, x)
         @test gini_norm(p, y) > 0.8
     end
+
+    @testset "logistic_mle metric" begin
+
+        # Closed-form log-density of the logistic distribution with location mu and
+        # scale s: -(y-mu)/s - log(s) - 2*log(1 + exp(-(y-mu)/s)).
+        true_lpdf(y, mu, s) = -(y - mu) / s - log(s) - 2 * log1p(exp(-(y - mu) / s))
+
+        for (mu, s) in ((0.5, 2.0), (-1.0, 0.5), (0.0, 1.0))
+            ls = log(s)
+            for y in (mu, mu + 0.7, mu + 3.5, mu - 3.5, mu + 12.0)
+                @test EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, y) ≈
+                      true_lpdf(y, mu, s)
+            end
+        end
+
+        # The metric is the log-likelihood of the objective being optimised, so its
+        # derivative must agree with the gradient the loss uses, up to sign.
+        mu, ls, h = 0.5, log(2.0), 1e-6
+        for y in (1.5, 4.0, -3.0)
+            d = (EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu + h, ls, y) -
+                 EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu - h, ls, y)) / (2h)
+            g = EvoTrees.mle2p_grad_hess(EvoTrees.LogisticMLE, mu, ls, y)[1]
+            @test d ≈ -g atol = 1e-5
+        end
+
+        # Symmetric about the location, and maximised there.
+        mu, ls = 0.5, log(2.0)
+        @test EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu + 2.0) ≈
+              EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu - 2.0)
+        @test EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu) >
+              EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu + 2.0)
+    end
 end


### PR DESCRIPTION
The `logistic_mle` eval metric does not match the objective it reports on. The logistic density with location `mu` and scale `s` is `(1/4s) * sech((y-mu)/(2s))^2`, but `_mle2p_metric_value` evaluates `sech((y-mu)/s)`, dropping the factor of 2 in the argument. The gradient in `mle2p_grad_hess` uses the correct `(yt - μ) / (2 * exp(ls))`, so the reported metric and the optimised loss disagree.

With `mu=0.5` and `s=2.0` the metric returns -2.319672 at `y=1.5` and -4.252654 at `y=4.0`, against a true log-density of -2.141301 and -2.763595. They agree only at `y = mu`, where the argument is zero, and diverge as the residual grows. Since `is_maximise(logistic_mle) = true` drives early stopping, training also stops on the wrong signal.

Fixed in both the CPU and CUDA copies. After the fix the metric matches the closed form exactly, and its derivative agrees with the gradient the loss uses: `d(metric)/dmu = 0.122459` against `-g1 = 0.122459`, where the previous value was -0.462117.

Adds tests in `test/metrics.jl` checking the metric against the closed-form density over several location and scale combinations, that its numerical derivative matches `mle2p_grad_hess`, and that it is symmetric about the location and maximised there. They fail on current `main`.