### PR TITLE
Error on a single-level classification target

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -55,6 +55,10 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
             @error "Invalid target eltype: $(eltype(y_train))"
         end
         K = length(target_levels)
+        K < 2 && error(
+            "Classification requires a target with at least 2 levels, got $K: " *
+            "$(string.(target_levels)). A single-class problem is not meaningful."
+        )
         μ = T.(log.(proportions(y, UInt32(1):UInt32(K))))
         μ .-= maximum(μ)
         !isnothing(offset) && (offset .= log.(offset))

--- a/test/MLJ.jl
+++ b/test/MLJ.jl
@@ -409,3 +409,10 @@ end
     yhat = predict(mach, X)
     @assert isordered(yhat)
 end
+
+@testset "MLJ - single-class target" begin
+    X = (; x=rand(Xoshiro(11), 10))
+    y = coerce(fill("a", 10), OrderedFactor)
+    mach = machine(EvoTreeClassifier(), X, y)
+    @test_throws Exception fit!(mach, verbosity=0)
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -536,4 +536,25 @@ end
         end
     end
 
+    @testset "classifier target levels" begin
+        rng = Xoshiro(7)
+        x = rand(rng, 40, 3)
+
+        for (y, k) in ((repeat(["a", "b", "c"], 20)[1:40], 3), (repeat(["a", "b"], 20), 2))
+            m = fit(EvoTreeClassifier(nrounds=3); x_train=x, y_train=y)
+            @test m.K == k
+            @test size(predict(m, x)) == (40, k)
+        end
+
+        # A single-level target is not a meaningful classification problem, and is
+        # rejected at fit rather than producing a degenerate model.
+        @test_throws ErrorException fit(
+            EvoTreeClassifier(nrounds=3); x_train=x, y_train=fill("a", 40)
+        )
+        @test_throws ErrorException fit(
+            EvoTreeClassifier(nrounds=3); x_train=x,
+            y_train=categorical(fill("a", 40), levels=["a"]),
+        )
+    end
+
 end


### PR DESCRIPTION
A single-level classification target currently produces a degenerate model rather than an error. `K` ends up as 1, and predicting through the MLJ interface then fails with `DimensionMismatch: Probability array is incompatible with the number of classes` out of `UnivariateFinite`, which gives no indication of the actual problem.

Following your preference for an upstream control, `init_core` now rejects it at fit:

```
Classification requires a target with at least 2 levels, got 1: ["a"]. A single-class problem is not meaningful.
```

This is the underlying cause of the ordered factor test flakiness patched in dc9aabd, where `rand("ab", 10)` occasionally produced a target with a single class.

Adds tests for the error on both a plain vector and a categorical target, that two and three level targets are unaffected, and the MLJ path with a single-level target.