### PR TITLE
Return zero importance when a model contains no splits

### DIFF
--- a/src/importance.jl
+++ b/src/importance.jl
@@ -19,8 +19,12 @@ function importance(model::EvoTree; feature_names=model.info[:feature_names])
         importance!(gain, tree)
     end
 
-    gain .= gain ./ sum(gain)
-    pairs = collect(Dict(zip(Symbol.(feature_names), gain)))
+    # A model can contain no split at all (`max_depth = 1`, `nrounds = 0`, or a `gamma` high
+    # enough to reject every candidate), in which case the total gain is zero and normalising
+    # would return `NaN` for every feature.
+    total = sum(gain)
+    total > 0 && (gain ./= total)
+    pairs = [Symbol(name) => g for (name, g) in zip(feature_names, gain)]
     sort!(pairs, by=x -> -x[2])
 
     return pairs

--- a/test/core.jl
+++ b/test/core.jl
@@ -557,4 +557,34 @@ end
         )
     end
 
+    @testset "importance with no splits" begin
+        rng = Xoshiro(11)
+        x = rand(rng, 300, 4)
+        y = rand(rng, 300)
+
+        # A model with no split anywhere has zero total gain. Normalising by that total
+        # would give NaN for every feature, so the zeros are returned as they are.
+        for config in (
+            EvoTreeRegressor(nrounds=5, max_depth=1),
+            EvoTreeRegressor(nrounds=0),
+            EvoTreeRegressor(nrounds=5, max_depth=4, gamma=1e9),
+        )
+            m = fit(config; x_train=x, y_train=y)
+            imp = EvoTrees.importance(m)
+            @test !any(isnan(v) for (_, v) in imp)
+            @test all(v == 0 for (_, v) in imp)
+            @test length(imp) == 4
+        end
+
+        # A model that does split still normalises to one.
+        m = fit(EvoTreeRegressor(nrounds=20, max_depth=4); x_train=x, y_train=y)
+        imp = EvoTrees.importance(m)
+        @test sum(v for (_, v) in imp) ≈ 1
+        @test issorted([v for (_, v) in imp]; rev=true)
+
+        # Ordering is stable across calls, and duplicate names are not collapsed.
+        @test first.(EvoTrees.importance(m)) == first.(EvoTrees.importance(m))
+        @test length(EvoTrees.importance(m; feature_names=[:a, :a, :b, :c])) == 4
+    end
+
 end


### PR DESCRIPTION
`EvoTrees.importance` returns `NaN` for every feature when a model contains no split. The gain vector is normalised with `gain .= gain ./ sum(gain)`, and that total is zero in such a model.

Three realistic paths reach it: `max_depth=1`, `nrounds=0`, and a `gamma` high enough that no candidate split is accepted.

```julia
m = fit(EvoTreeRegressor(nrounds=5, max_depth=1); x_train=x, y_train=y)
EvoTrees.importance(m)
# [:feat_1 => NaN, :feat_3 => NaN, :feat_4 => NaN, :feat_2 => NaN]
```

It reaches MLJ too, where `feature_importances` returns `[:a => NaN, :b => NaN, :c => NaN]`.

The zeros are now returned as they are when the total gain is zero.

This also replaces `collect(Dict(zip(...)))` with direct pair construction. The dictionary round trip returned ties in hash order rather than feature order, so repeated calls on the same model could disagree, and duplicate names passed through `feature_names` were silently collapsed.

Tests cover the three no-split paths, that a model which does split still normalises to one, ordering stability across calls, and that duplicate names are preserved. They fail on current `main`.
