### PR TITLE
Fix poisson deviance metric for zero-valued targets

### DIFF
--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -230,4 +230,31 @@ using EvoTrees: fit, predict, gini_raw, gini_norm
             end
         end
     end
+
+    @testset "poisson metric with zero counts" begin
+
+        for pk in (-1.0, 0.0, 0.5)
+            @test EvoTrees._metric_value(EvoTrees.Poisson, pk, 0.0, 0.5) ≈ 2 * exp(pk)
+        end
+
+        dev(y, mu) = 2 * (y * log(y / mu) + mu - y)
+        for (pk, y) in ((0.0, 1.0), (0.5, 3.0), (-0.7, 2.0))
+            @test EvoTrees._metric_value(EvoTrees.Poisson, pk, y, 0.5) ≈ dev(y, exp(pk))
+        end
+        @test EvoTrees._metric_value(EvoTrees.Poisson, log(2.0), 2.0, 0.5) ≈ 0 atol = 1e-12
+
+        p = zeros(1, 3)
+        @test isfinite(EvoTrees.poisson(p, [0.0, 1.0, 2.0], ones(3), zeros(3)))
+
+        nobs = 1_000
+        Random.seed!(123)
+        x = rand(nobs, 5)
+        y = Float64.(rand(0:3, nobs))
+        @test any(iszero, y)
+
+        config = EvoTreeCount(nrounds=20, eta=0.2, early_stopping_rounds=3)
+        m = fit(config; x_train=x, y_train=y, x_eval=x, y_eval=y, verbosity=0)
+        @test all(isfinite, m.info[:logger][:metrics])
+        @test m.info[:nrounds] == 20
+    end
 end


### PR DESCRIPTION
The NaN this PR was opened for is already gone from main. The KernelAbstractions migration moved the CUDA epsilon form into `src/metrics.jl`, and `2 * (y * log(y / mu + eps) + mu - y)` gives the right answer at `y = 0`, so there is nothing left to change in the source. I rebased and dropped the source changes. What is left is the regression tests.

`test/metrics.jl` on main has no poisson coverage at all. These cover the deviance at zero counts, the closed form for positive counts, that it vanishes when the prediction equals the count, and an `EvoTreeCount` fit with zeros in the eval target that has to reach all 20 rounds.

They pass on main, 123 of 123 in `test/metrics.jl`, and the full suite is green at 633 of 633. Putting the pre-migration expression `2 * (y * (log(y) - log(mu)) + mu - y)` back fails 6 of the 11 new checks, so they pin the behaviour rather than just riding along with it.

I also checked whether the epsilon is worth replacing with the `y * log(y) = 0` convention, and it is not. Measured against a BigFloat reference over `y` in `0:100` and raw scores in `-2:2`, the worst absolute error at Float32, which is what training runs in, is the same for both forms at `4.5e-5`. So the epsilon costs nothing and I left it alone.
