### PR TITLE
Apply the single-level target check to the GPU init path

### DIFF
--- a/ext/EvoTreesCUDAExt/init.jl
+++ b/ext/EvoTreesCUDAExt/init.jl
@@ -53,6 +53,10 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, ::Type{<:EvoTrees.GPU}, d
             @error "Invalid target eltype: $(eltype(y_train))"
         end
         K = length(target_levels)
+        K < 2 && error(
+            "Classification requires a target with at least 2 levels, got $K: " *
+            "$(string.(target_levels)). A single-class problem is not meaningful."
+        )
         μ = T.(log.(EvoTrees.proportions(y, UInt32(1):UInt32(K))))
         μ .-= maximum(μ)
         !isnothing(offset) && (offset .= log.(offset))


### PR DESCRIPTION
PR #349 rejects a classification target with fewer than 2 levels, but the check only landed in `src/init.jl`. `EvoTrees.init_core` for `GPU` in `ext/EvoTreesCUDAExt/init.jl` is a separate method and still runs the old path, so `device=:gpu` builds the degenerate single-class model that #349 was meant to prevent.

```
$ git show --stat --format="" feed3ea
 src/init.jl  |  4 ++++
 test/MLJ.jl  |  7 +++++++
 test/core.jl | 23 ++++++++++++++++++++++-

$ grep -c "at least 2 levels" src/init.jl ext/EvoTreesCUDAExt/init.jl
ext/EvoTreesCUDAExt/init.jl:0
src/init.jl:1
```

This copies the check to the same position in the GPU branch, right after `K = length(target_levels)`, with the same message, so both devices fail the same way.

I have no GPU here so I could not exercise the GPU path itself. What I did check is that the extension still compiles with the change, by loading EvoTrees with CUDA, KernelAbstractions and Atomix present so the extension is triggered. The CPU tests added in #349 already cover the behaviour and CI has no GPU runner, so I did not add a test.
