### PR TITLE
Truncate the model to the best iteration when early stopping fires

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -339,9 +339,38 @@ function fit(
     end
     post_fit_gc(_device)
     m.info[:logger] = logger
+    truncate_to_best_iter!(m)
 
     return m
 
+end
+
+
+"""
+    truncate_to_best_iter!(m::EvoTree)
+
+Drop the trees grown after the best iteration recorded by early stopping.
+
+Early stopping keeps boosting for `early_stopping_rounds` after the optimum in order to confirm
+it, and those extra rounds are overfit by construction. Without this the model returned is the
+one at the stopping point rather than the one early stopping selected, and the gap grows with
+`early_stopping_rounds`.
+
+No-op when no evaluation set was supplied, when early stopping never fired, or when the best
+iteration is the last one.
+"""
+function truncate_to_best_iter!(m::EvoTree)
+    logger = get(m.info, :logger, nothing)
+    isnothing(logger) && return m
+    nrounds = m.info[:nrounds]
+    best_iter = logger[:best_iter]
+    (best_iter <= 0 || best_iter >= nrounds) && return m
+    # the first tree carries the bias, the remainder are `bagging_size` per round
+    bagging_size = (length(m.trees) - 1) ÷ nrounds
+    keep = 1 + best_iter * bagging_size
+    resize!(m.trees, keep)
+    m.info[:nrounds] = best_iter
+    return m
 end
 
 """
@@ -431,6 +460,7 @@ function fit(
     end
     post_fit_gc(_device)
     m.info[:logger] = logger
+    truncate_to_best_iter!(m)
 
     return m
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -350,9 +350,38 @@ function fit(
     end
     post_fit_gc(_device)
     m.info[:logger] = logger
+    truncate_to_best_iter!(m)
 
     return m
 
+end
+
+
+"""
+    truncate_to_best_iter!(m::EvoTree)
+
+Drop the trees grown after the best iteration recorded by early stopping.
+
+Early stopping keeps boosting for `early_stopping_rounds` after the optimum in order to confirm
+it, and those extra rounds are overfit by construction. Without this the model returned is the
+one at the stopping point rather than the one early stopping selected, and the gap grows with
+`early_stopping_rounds`.
+
+No-op when no evaluation set was supplied, when early stopping never fired, or when the best
+iteration is the last one.
+"""
+function truncate_to_best_iter!(m::EvoTree)
+    logger = get(m.info, :logger, nothing)
+    isnothing(logger) && return m
+    nrounds = m.info[:nrounds]
+    best_iter = logger[:best_iter]
+    (best_iter <= 0 || best_iter >= nrounds) && return m
+    # the first tree carries the bias, the remainder are `bagging_size` per round
+    bagging_size = (length(m.trees) - 1) ÷ nrounds
+    keep = 1 + best_iter * bagging_size
+    resize!(m.trees, keep)
+    m.info[:nrounds] = best_iter
+    return m
 end
 
 """
@@ -448,6 +477,7 @@ function fit(
     end
     post_fit_gc(_device)
     m.info[:logger] = logger
+    truncate_to_best_iter!(m)
 
     return m
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -376,9 +376,9 @@ function truncate_to_best_iter!(m::EvoTree)
     nrounds = m.info[:nrounds]
     best_iter = logger[:best_iter]
     (best_iter <= 0 || best_iter >= nrounds) && return m
-    # the first tree carries the bias, the remainder are `bagging_size` per round
-    bagging_size = (length(m.trees) - 1) ÷ nrounds
-    keep = 1 + best_iter * bagging_size
+    # `trees` holds only boosting rounds, `bagging_size` of them per round
+    bagging_size = length(m.trees) ÷ nrounds
+    keep = best_iter * bagging_size
     resize!(m.trees, keep)
     m.info[:nrounds] = best_iter
     return m

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -376,6 +376,9 @@ function truncate_to_best_iter!(m::EvoTree)
     nrounds = m.info[:nrounds]
     best_iter = logger[:best_iter]
     (best_iter <= 0 || best_iter >= nrounds) && return m
+    # only when early stopping actually fired: an eval set passed for monitoring alone must
+    # return every tree the user asked for
+    logger[:iter_since_best] >= logger[:early_stopping_rounds] || return m
     # `trees` holds only boosting rounds, `bagging_size` of them per round
     bagging_size = length(m.trees) ÷ nrounds
     keep = best_iter * bagging_size

--- a/test/core.jl
+++ b/test/core.jl
@@ -557,4 +557,49 @@ end
         )
     end
 
+    @testset "early stopping returns the best iteration" begin
+        rng = Xoshiro(1)
+        n = 4_000
+        x = rand(rng, n, 10)
+        y = sin.(x[:, 1] .* 3) .+ 1.5 .* randn(rng, n)
+        xt, yt = x[1:2500, :], y[1:2500]
+        xe, ye = x[2501:end, :], y[2501:end]
+
+        # The trees grown while confirming the optimum are overfit by construction, so the
+        # returned model must not depend on how long early stopping waits.
+        results = map((10, 25, 50, 100)) do esr
+            m = fit(
+                EvoTreeRegressor(nrounds=1000, max_depth=6, eta=0.1,
+                                 early_stopping_rounds=esr, metric=:mse);
+                x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+            )
+            @test m.info[:nrounds] == m.info[:logger][:best_iter]
+            @test length(m.trees) == 1 + m.info[:logger][:best_iter]
+            sqrt(mean((predict(m, xe) .- ye) .^ 2))
+        end
+        @test all(r -> r ≈ results[1], results)
+
+        # Without an eval set there is no logger and nothing is dropped.
+        m = fit(EvoTreeRegressor(nrounds=30, max_depth=4); x_train=xt, y_train=yt)
+        @test m.info[:nrounds] == 30
+        @test length(m.trees) == 31
+
+        # `bagging_size` trees are grown per round, so truncation must account for it.
+        mb = fit(
+            EvoTreeRegressor(nrounds=1000, max_depth=6, eta=0.1, bagging_size=3,
+                             early_stopping_rounds=15, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+        )
+        @test length(mb.trees) == 1 + 3 * mb.info[:nrounds]
+        @test mb.info[:nrounds] == mb.info[:logger][:best_iter]
+
+        # A run that improves to the final round keeps every tree.
+        mf = fit(
+            EvoTreeRegressor(nrounds=5, max_depth=4, eta=0.5, early_stopping_rounds=100, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xt, y_eval=yt, verbosity=0,
+        )
+        @test mf.info[:nrounds] == 5
+        @test length(mf.trees) == 6
+    end
+
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -680,6 +680,51 @@ end
         end
     end
 
+    @testset "early stopping returns the best iteration" begin
+        rng = Xoshiro(1)
+        n = 4_000
+        x = rand(rng, n, 10)
+        y = sin.(x[:, 1] .* 3) .+ 1.5 .* randn(rng, n)
+        xt, yt = x[1:2500, :], y[1:2500]
+        xe, ye = x[2501:end, :], y[2501:end]
+
+        # The trees grown while confirming the optimum are overfit by construction, so the
+        # returned model must not depend on how long early stopping waits.
+        results = map((10, 25, 50, 100)) do esr
+            m = fit(
+                EvoTreeRegressor(nrounds=1000, max_depth=6, eta=0.1,
+                                 early_stopping_rounds=esr, metric=:mse);
+                x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+            )
+            @test m.info[:nrounds] == m.info[:logger][:best_iter]
+            @test length(m.trees) == 1 + m.info[:logger][:best_iter]
+            sqrt(mean((predict(m, xe) .- ye) .^ 2))
+        end
+        @test all(r -> r ≈ results[1], results)
+
+        # Without an eval set there is no logger and nothing is dropped.
+        m = fit(EvoTreeRegressor(nrounds=30, max_depth=4); x_train=xt, y_train=yt)
+        @test m.info[:nrounds] == 30
+        @test length(m.trees) == 31
+
+        # `bagging_size` trees are grown per round, so truncation must account for it.
+        mb = fit(
+            EvoTreeRegressor(nrounds=1000, max_depth=6, eta=0.1, bagging_size=3,
+                             early_stopping_rounds=15, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+        )
+        @test length(mb.trees) == 1 + 3 * mb.info[:nrounds]
+        @test mb.info[:nrounds] == mb.info[:logger][:best_iter]
+
+        # A run that improves to the final round keeps every tree.
+        mf = fit(
+            EvoTreeRegressor(nrounds=5, max_depth=4, eta=0.5, early_stopping_rounds=100, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xt, y_eval=yt, verbosity=0,
+        )
+        @test mf.info[:nrounds] == 5
+        @test length(mf.trees) == 6
+    end
+
 end
 
 @testset "bias distinct from trees" begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -725,6 +725,16 @@ end
         @test length(m1.trees) == m1.info[:nrounds]
         @test m1.info[:nrounds] == m1.info[:logger][:best_iter]
 
+        # An eval set supplied for monitoring only, with early stopping never firing, must
+        # return every tree that was asked for.
+        mm = fit(
+            EvoTreeRegressor(nrounds=30, max_depth=6, eta=0.1, early_stopping_rounds=10_000, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+        )
+        @test mm.info[:nrounds] == 30
+        @test length(mm.trees) == 30
+        @test mm.info[:logger][:metrics][end] ≈ mean((predict(mm, xe) .- ye) .^ 2)
+
         # A run that improves to the final round keeps every tree.
         mf = fit(
             EvoTreeRegressor(nrounds=5, max_depth=4, eta=0.5, early_stopping_rounds=100, metric=:mse);

--- a/test/core.jl
+++ b/test/core.jl
@@ -697,7 +697,7 @@ end
                 x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
             )
             @test m.info[:nrounds] == m.info[:logger][:best_iter]
-            @test length(m.trees) == 1 + m.info[:logger][:best_iter]
+            @test length(m.trees) == m.info[:logger][:best_iter]
             sqrt(mean((predict(m, xe) .- ye) .^ 2))
         end
         @test all(r -> r ≈ results[1], results)
@@ -705,7 +705,7 @@ end
         # Without an eval set there is no logger and nothing is dropped.
         m = fit(EvoTreeRegressor(nrounds=30, max_depth=4); x_train=xt, y_train=yt)
         @test m.info[:nrounds] == 30
-        @test length(m.trees) == 31
+        @test length(m.trees) == 30
 
         # `bagging_size` trees are grown per round, so truncation must account for it.
         mb = fit(
@@ -713,8 +713,17 @@ end
                              early_stopping_rounds=15, metric=:mse);
             x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
         )
-        @test length(mb.trees) == 1 + 3 * mb.info[:nrounds]
+        @test length(mb.trees) == 3 * mb.info[:nrounds]
         @test mb.info[:nrounds] == mb.info[:logger][:best_iter]
+
+        # `bagging_size` defaults to 1, where the per-round tree count must still be 1.
+        m1 = fit(
+            EvoTreeRegressor(nrounds=1000, max_depth=6, eta=0.1, bagging_size=1,
+                             early_stopping_rounds=15, metric=:mse);
+            x_train=xt, y_train=yt, x_eval=xe, y_eval=ye, verbosity=0,
+        )
+        @test length(m1.trees) == m1.info[:nrounds]
+        @test m1.info[:nrounds] == m1.info[:logger][:best_iter]
 
         # A run that improves to the final round keeps every tree.
         mf = fit(
@@ -722,7 +731,7 @@ end
             x_train=xt, y_train=yt, x_eval=xt, y_eval=yt, verbosity=0,
         )
         @test mf.info[:nrounds] == 5
-        @test length(mf.trees) == 6
+        @test length(mf.trees) == 5
     end
 
 end


### PR DESCRIPTION
Trees grown after the best iteration are dropped when early stopping fires, so the returned model is the one early stopping selected rather than the one at the stopping point.

PR to address #356. This implements option 1 from that issue. I can switch to option 2 instead, keeping every tree and having `predict` default to the best iteration.

Holding everything fixed and varying only `early_stopping_rounds`, test rmse before and after:

```
patience   before     after
10         1.52684    1.52136
25         1.53666    1.52136
50         1.55011    1.52136
100        1.58328    1.52136
```

`best_iter` was already stable at 6 in every one of those runs, so the optimum was always located correctly; only the delivered model varied.

`truncate_to_best_iter!` is a no-op when no eval set was supplied, when the best iteration is the last one, and when early stopping never fired. That last case matters on its own: an eval set is often passed for monitoring with no intention of stopping early, and such a fit has to return every tree that was asked for. The check is `iter_since_best >= early_stopping_rounds`.

It derives `bagging_size` from `length(m.trees) ÷ nrounds`, so the mapping from rounds to trees holds when more than one tree is grown per round, and it sets `info[:nrounds]` to match the retained trees.

Tests cover the four patience values agreeing, the tree count and `nrounds` matching `best_iter`, a model fitted without an eval set keeping every tree, an eval set with early stopping never firing keeping every tree and its last logged metric still matching the returned model, `bagging_size` at 1 and 3, and a run that improves to the final round.

Rebased on current main. #384 moved the intercept off `trees[1]`, so `trees` now holds `nrounds * bagging_size` entries and the round-to-tree arithmetic here drops the offset it used to carry.
