### PR TITLE
Fix multiclass hessian to the softmax diagonal

### DIFF
--- a/src/loss.jl
+++ b/src/loss.jl
@@ -94,7 +94,7 @@ end
 # K classes and so is accumulated by the caller before this is applied per-class.
 @inline function mlogloss_grad_hess(pk, isum, is_target)
     prob = exp(pk) / isum
-    return (is_target ? prob - one(prob) : prob, (1 - prob) / isum)
+    return (is_target ? prob - one(prob) : prob, prob * (1 - prob))
 end
 
 function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{L}, params::EvoTypes) where {T,L<:GradientRegression}

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -97,4 +97,31 @@ using EvoTrees: fit, predict, gini_raw, gini_norm
         @test EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu) >
               EvoTrees._mle2p_metric_value(EvoTrees.LogisticMLE, mu, ls, mu + 2.0)
     end
+
+    @testset "mlogloss gradient and hessian" begin
+
+        # Softmax cross-entropy for a single observation with target class k.
+        loss(p, k) = log(sum(exp, p)) - p[k]
+
+        # Equal logits are the initialisation state, and are not on their own a
+        # sufficient check: the diagonal hessian prob*(1-prob) and the expression
+        # (1-prob)/isum coincide exactly when every logit is equal. The points below
+        # are deliberately unequal so that the two disagree.
+        target = 2
+        for p in ([0.0, 0.0, 0.0], [2.0, 1.0, 0.0], [1.0, -0.5, 0.3], [-1.0, -1.0, 2.0])
+            isum = sum(exp, p)
+            h = 1e-5
+            for k in eachindex(p)
+                g, hess = EvoTrees.mlogloss_grad_hess(p[k], isum, k == target)
+                pp = copy(p)
+                pp[k] += h
+                pm = copy(p)
+                pm[k] -= h
+                @test g ≈ (loss(pp, target) - loss(pm, target)) / (2h) atol = 1e-5
+                @test hess ≈
+                      (loss(pp, target) - 2 * loss(p, target) + loss(pm, target)) / h^2 atol =
+                    1e-4
+            end
+        end
+    end
 end


### PR DESCRIPTION
The diagonal hessian of the softmax cross-entropy is `prob * (1 - prob)`, but `mlogloss_grad_hess` returns `(1 - prob) / isum`, dropping the `exp(pk)` from the numerator. The gradient in the same function is correct, so the model still trains and the error is only in the second order term.

The two expressions agree exactly when every logit is equal, since `1/isum` is then `prob`. That is the initialisation state, so the first boosting round is right and the error grows as the model fits. Against a finite difference of `log(sum(exp(p))) - p[target]`:

```
p = [2.0, 1.0, 0.0]     k=1   hessian 0.030139   true 0.222695
p = [1.0, -0.5, 0.3]    k=2   hessian 0.186163   true 0.112914
p = [0.0, 0.0, 0.0]     k=1   hessian 0.222222   true 0.222222
```

This feeds both the leaf newton step and `get_gain`, so it also distorts which splits are selected rather than only how far a leaf moves. On five independent problems, 12k rows, depth 5, eta 0.1, 100 rounds, holdout mlogloss and accuracy before and after:

```
K=3  linear      0.26670 -> 0.16609    0.92000 -> 0.94933
K=5  linear      0.52511 -> 0.32319    0.83933 -> 0.90333
K=4  nonlinear   0.41421 -> 0.25621    0.87567 -> 0.92033
K=10 linear      0.94871 -> 0.54339    0.71700 -> 0.82867
K=2  nonlinear   0.09543 -> 0.05784    0.97467 -> 0.98267
```

Consistently 38 to 43 percent of the logloss, with the accuracy gain scaling in the number of classes. On a rounds sweep at K=5 the fixed model reaches 0.32319 at 100 rounds against 0.42076 for the current one at 200, so it is also roughly half the trees for the same quality.

Since the kernelabstraction migration shares the scalar helper, the one line covers CPU and GPU both.

Adds a testset in `test/metrics.jl` checking gradient and hessian against finite differences at four points. Three of them use unequal logits deliberately: the all-equal case passes either way, which is what let this survive. The hessian assertions fail on the current code and the gradient assertions pass, which isolates the change.
