### PR TITLE
Pass alpha to the quantile eval metric

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -48,7 +48,7 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(deval, _weight_name))
-    metric_kwargs = (;)
+    metric_kwargs = hasproperty(params, :alpha) ? (alpha=T(params.alpha),) : (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)
         device <: GPU && (alphas_eval = V{T}(alphas_eval))
@@ -98,7 +98,7 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(w_eval) ? device_ones(device, T, size(x_eval, 1)) : V{T}(w_eval)
-    metric_kwargs = (;)
+    metric_kwargs = hasproperty(params, :alpha) ? (alpha=T(params.alpha),) : (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)
         device <: GPU && (alphas_eval = V{T}(alphas_eval))

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -66,6 +66,33 @@ using EvoTrees: fit, predict, gini_raw, gini_norm
         @test gini_norm(p, y) > 0.8
     end
 
+    @testset "quantile metric alpha" begin
+
+        # The eval callback must pass the model's own `alpha` to the metric. It used to
+        # leave `metric_kwargs` empty for `:quantile`, so the metric fell back to its
+        # `alpha = 0.5` default and always reported the median pinball loss.
+        pinball(p, y, a) = mean(@. a * max(y - p, 0) + (1 - a) * max(p - y, 0))
+
+        Random.seed!(3)
+        nobs = 4_000
+        x = rand(nobs, 3)
+        y = 2 .* x[:, 1] .+ 0.5 .* randn(nobs)
+        itr, ite = 1:3_000, 3_001:nobs
+
+        # alpha = 0.5 is not on its own a sufficient check: it is the metric's default,
+        # so it agrees whether or not alpha is plumbed through.
+        for alpha in (0.1, 0.5, 0.9)
+            m = fit(
+                EvoTreeRegressor(;
+                    loss=:quantile, alpha, nrounds=25, max_depth=4, metric=:quantile);
+                x_train=x[itr, :], y_train=y[itr],
+                x_eval=x[ite, :], y_eval=y[ite], verbosity=0)
+            reported = m.info[:logger][:metrics][end]
+            p = predict(m, x[ite, :])
+            @test reported ≈ pinball(p, y[ite], alpha) rtol = 1e-4
+        end
+    end
+
     @testset "MLE metrics" begin
         gaussian_lpdf(y, loc, scale) = -(log(scale) + (y - loc)^2 / (2 * scale^2))
         logistic_lpdf(y, loc, scale) = -(y - loc) / scale - log(scale) - 2 * log1p(exp(-(y - loc) / scale))


### PR DESCRIPTION
`metric=:quantile` always reports the median pinball loss, whatever `alpha` the model was fit with. The pinball loss itself takes `alpha` and `_eval_metric` accepts it as a keyword defaulting to 0.5, but `CallBack` only populates `metric_kwargs` for `:multiquantile`, so for `:quantile` the tuple stays empty and the model's own `alpha` never reaches the metric.

Fitting `loss=:quantile` at three alphas and comparing the reported eval metric against the pinball loss computed by hand:

```
alpha    reported    pinball@alpha    pinball@0.5
0.1      0.351732    0.090966         0.351732
0.5      0.201107    0.201107         0.201107
0.9      0.322877    0.088722         0.322877
```

The reported value is `pinball@0.5` in every case. The `alpha=0.5` row agreeing is why this is easy to miss when testing the default.

Since the reported number is not the loss being optimised, early stopping also fires on the wrong signal. With `nrounds=300` and `early_stopping_rounds=15`:

```
             best_iter   trees   reported    true pinball@alpha
alpha=0.1
  current    10          25      0.29709     0.099531
  fixed      64          79      0.090949    0.090949
alpha=0.9
  current    13          28      0.28027     0.101000
  fixed      87          102     0.088931    0.088931
```

Training stops at iteration 10 to 13 instead of 64 to 87, and the model returned is 9 to 12 percent worse on its own objective. After the fix the reported metric equals the true pinball loss exactly, which is the check that it is now the right quantity.

Passing `alpha` unconditionally is safe because every metric already accepts and ignores unknown keywords, so this needs no branch on the metric name.

Adds a testset in `test/metrics.jl` asserting the reported metric matches the pinball loss at the model's own alpha for 0.1, 0.5 and 0.9. The 0.1 and 0.9 cases fail on the current code and 0.5 passes either way, since it is the metric's default.
