### PR TITLE
Encode eval target against the model's training levels

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -1,3 +1,23 @@
+_raw_level(x) = x isa CategoricalValue ? CategoricalArrays.unwrap(x) : x
+
+"""
+    eval_levelcode(y_eval, target_levels)
+
+Encode `y_eval` against the class levels the model was trained on, rather than against the
+levels present in `y_eval` itself. An eval set that is missing a training class, or that
+orders its own levels differently, would otherwise be scored against the wrong prediction
+columns.
+"""
+function eval_levelcode(y_eval, target_levels)
+    idx = indexin(y_eval, target_levels)
+    if any(isnothing, idx)
+        unseen = unique(_raw_level.(y_eval[findall(isnothing, idx)]))
+        error("`y_eval` contains levels absent from `y_train`: $(unseen). " *
+              "Training levels are $(_raw_level.(target_levels)).")
+    end
+    return UInt32.(idx)
+end
+
 struct CallBack{B,P,Y,C,D,K}
     feval::Function
     x_bin::B
@@ -32,16 +52,7 @@ function CallBack(
         permutedims(reduce(hcat, [Tables.getcolumn(deval, t) for t in _target_names]))
 
     if L == MLogLoss
-        if eltype(y_eval) <: CategoricalValue
-            levels = CategoricalArrays.levels(y_eval)
-            μ = zeros(T, K)
-            y = UInt32.(CategoricalArrays.levelcode.(y_eval))
-        else
-            levels = sort(unique(y_eval))
-            yc = CategoricalVector(y_eval, levels=levels)
-            μ = zeros(T, K)
-            y = UInt32.(CategoricalArrays.levelcode.(yc))
-        end
+        y = eval_levelcode(y_eval, m.info[:target_levels])
     else
         y = T.(y_eval)
     end
@@ -82,16 +93,7 @@ function CallBack(
     p = zeros(T, K, size(x_eval, 1))
 
     if L == MLogLoss
-        if eltype(y_eval) <: CategoricalValue
-            levels = CategoricalArrays.levels(y_eval)
-            μ = zeros(T, K)
-            y = UInt32.(CategoricalArrays.levelcode.(y_eval))
-        else
-            levels = sort(unique(y_eval))
-            yc = CategoricalVector(y_eval, levels=levels)
-            μ = zeros(T, K)
-            y = UInt32.(CategoricalArrays.levelcode.(yc))
-        end
+        y = eval_levelcode(y_eval, m.info[:target_levels])
     else
         y = T.(y_eval)
     end

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -93,6 +93,44 @@ using EvoTrees: fit, predict, gini_raw, gini_norm
         end
     end
 
+    @testset "eval class encoding" begin
+
+        # The eval callback must encode `y_eval` against the levels the model was trained
+        # on. It used to derive them from `y_eval` itself, so an eval fold missing a
+        # training class was scored against the wrong prediction columns.
+        Random.seed!(1)
+        nobs = 4_000
+        x = rand(nobs, 3)
+        z = 2 .* x[:, 1] .- x[:, 2]
+        y = [zi < -0.3 ? 1 : (zi < 0.5 ? 2 : 3) for zi in z]
+
+        # mlogloss computed directly, mapping each label through the model's own levels.
+        function true_mlogloss(m, xe, ye)
+            p = predict(m, xe)
+            lv = m.info[:target_levels]
+            mean(-log(max(p[i, findfirst(==(ye[i]), lv)], 1e-15)) for i in eachindex(ye))
+        end
+
+        # A class-complete eval set agrees either way; the missing-class cases are what
+        # separate the two encodings.
+        for ie in (1:1_500, findall(y[1:2_000] .!= 1), findall(y[1:2_000] .== 3))
+            m = fit(
+                EvoTreeClassifier(; nrounds=20, max_depth=4, eta=0.1);
+                x_train=x, y_train=y,
+                x_eval=x[ie, :], y_eval=y[ie], verbosity=0)
+            @test m.info[:logger][:metrics][end] ≈ true_mlogloss(m, x[ie, :], y[ie]) rtol =
+                1e-4
+        end
+
+        # A level in `y_eval` that never appeared in `y_train` indexed past the end of the
+        # prediction matrix under `@inbounds`. It must be rejected instead.
+        tr = findall(y .!= 3)
+        @test_throws ErrorException fit(
+            EvoTreeClassifier(; nrounds=5, max_depth=3);
+            x_train=x[tr, :], y_train=y[tr],
+            x_eval=x[1:500, :], y_eval=y[1:500], verbosity=0)
+    end
+
     @testset "MLE metrics" begin
         gaussian_lpdf(y, loc, scale) = -(log(scale) + (y - loc)^2 / (2 * scale^2))
         logistic_lpdf(y, loc, scale) = -(y - loc) / scale - log(scale) - 2 * log1p(exp(-(y - loc) / scale))


### PR DESCRIPTION
The eval callback builds its class encoding from `y_eval` itself rather than from the levels the model was trained on. `m.info[:target_levels]` is written at fit and then read nowhere except `src/MLJ.jl:55`, so an eval set whose level set differs from the training one is scored against the wrong prediction columns.

The resulting integer is used directly as a row index into the prediction matrix in `mlogloss`, so the damage is silent. Three classes, 30 rounds, comparing the reported metric against the same quantity computed by hand through `target_levels`:

```
eval contains            reported    true
all 3 classes            0.18970     0.18970
missing class 1          3.25376     0.15333
missing class 2          2.85033     0.17334
only class 3             4.45472     0.11401
```

A class-complete eval set agrees, which is why this is easy to miss. A stratified split that drops a rare class, or a fold of an imbalanced multiclass problem, does not.

Since `is_maximise(mlogloss) = false` drives early stopping, training also stops on the wrong signal. With `nrounds=200` and `early_stopping_rounds=10` against an eval fold missing one class, the logger reports `best_iter = 0` and stops after 10 rounds, so the iteration recorded as best is the bias-only model.

Separately, a level present in `y_eval` but absent from `y_train` indexes past the end of the prediction matrix. `mlogloss` reads `p[y[i], i]` under `@inbounds`, so on a two-class model an eval label of 3 reads out of bounds and reports whatever it finds:

```
default (@inbounds active):   no error, metric 1.5913
--check-bounds=yes:           BoundsError, "attempt to access 2x2000 Matrix"
```

`eval_levelcode` now maps `y_eval` through `m.info[:target_levels]` with `indexin`, and rejects a level that never appeared in training rather than indexing past the end. This works uniformly for integer, string and categorical targets, since a raw value compares equal to its `CategoricalValue` level. Both `CallBack` constructors are covered, and `CallBack` is shared across backends so this is not CPU only. The dead `levels` and `μ` locals go with it.

Adds a testset in `test/metrics.jl` checking the reported metric against a direct computation for a class-complete eval set and two class-missing ones, and that an unseen eval level throws. The class-complete case passes either way, so the missing-class cases are what separate the two encodings.
