### PR TITLE
Throw instead of logging on invalid input

### DIFF
--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -48,7 +48,7 @@ function get_edges(df; feature_names, nbins, rng=Random.MersenneTwister(), kwarg
             featbins[j] = length(edges[j]) + 1
             feattypes[j] = true
         else
-            @error "Invalid feature eltype: $(feature_names[j]) is $(eltype(col))"
+            error("Invalid feature eltype: $(feature_names[j]) is $(eltype(col))")
         end
         if length(edges[j]) == 1
             edges[j] = [minimum(col)]
@@ -83,7 +83,7 @@ function binarize(df; feature_names, edges)
         elseif eltype(col) <: Real
             x_bin[:, j] .= searchsortedfirst.(Ref(edges[j]), col)
         else
-            @error "Invalid feature eltype: $(feature_names[j]) is $(eltype(col))"
+            error("Invalid feature eltype: $(feature_names[j]) is $(eltype(col))")
         end
     end
     return x_bin

--- a/src/init.jl
+++ b/src/init.jl
@@ -50,7 +50,7 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
             target_levels = CategoricalArrays.levels(yc)
             y = UInt32.(CategoricalArrays.levelcode.(yc))
         else
-            @error "Invalid target eltype: $(eltype(y_train))"
+            error("Invalid target eltype: $(eltype(y_train))")
         end
         K = length(target_levels)
         K < 2 && error(

--- a/src/subsample.jl
+++ b/src/subsample.jl
@@ -33,11 +33,8 @@ function subsample(left::AbstractVector, is::AbstractVector, mask_cond::Abstract
         end
     end
     counts_sum = sum(counts)
-    if counts_cum == 0
-        @error "no subsample observation - choose larger rowsample"
-    else
-        return view(is, 1:counts_sum)
-    end
+    counts_sum == 0 && error("no subsample observation - choose larger rowsample")
+    return view(is, 1:counts_sum)
 end
 
 # function subsample_single(is_in::AbstractVector, out::AbstractVector, mask::AbstractVector, rowsample::AbstractFloat, rng)

--- a/test/core.jl
+++ b/test/core.jl
@@ -555,6 +555,35 @@ end
             EvoTreeClassifier(nrounds=3); x_train=x,
             y_train=categorical(fill("a", 40), levels=["a"]),
         )
+
+        # An unsupported target eltype used to be reported with `@error`, which logs but
+        # does not throw, so execution continued to `length(target_levels)` with
+        # `target_levels` still `nothing` and the user saw a `MethodError` instead.
+        @test_throws ErrorException fit(
+            EvoTreeClassifier(nrounds=3); x_train=x, y_train=rand(40)
+        )
+    end
+
+    @testset "empty subsample" begin
+        rng = Xoshiro(11)
+        x = rand(rng, 40, 3)
+        y = 2 .* x[:, 1] .+ 0.2 .* randn(rng, 40)
+
+        # `cond` is `round(UInt8, 255 * rowsample)`, so a rowsample below 0.00196 keeps
+        # only mask bytes equal to zero, roughly 1 in 256 rows. On small data the draw
+        # comes up empty, which must be reported rather than silently producing a model
+        # that predicts the bias for every row.
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(nrounds=5, max_depth=3, rowsample=0.001, min_weight=0.0, seed=1);
+            x_train=x, y_train=y, verbosity=0
+        )
+
+        # A normal rowsample is unaffected.
+        m = fit(
+            EvoTreeRegressor(nrounds=10, max_depth=3, rowsample=0.5, seed=1);
+            x_train=x, y_train=y, verbosity=0
+        )
+        @test all(isfinite, predict(m, x))
     end
 
 end


### PR DESCRIPTION
`@error` logs and returns, it does not interrupt control flow, so each of the four places it is used as a rejection is a fall-through into a worse failure.

`subsample` is the clearest case. The guard is also testing the wrong variable:

```julia
counts_sum = sum(counts)
if counts_cum == 0
```

`counts_cum` is `cumsum(counts) .- counts`, a `Vector{Int}`, so comparing it to `0` is `false` for any input and the guard never fires. `counts_sum`, computed on the line above, is what was meant. Correcting only the condition would not be enough either: the branch would log and then fall out of the function returning `nothing`, which the caller assigns straight into `cache.nodes[1].is`.

The path is reachable. `cond` is `round(UInt8, 255 * rowsample)`, so any rowsample below 0.00196 keeps only mask bytes equal to zero, roughly 1 in 256 rows, and `check_args` permits any rowsample above `eps`. On small data the draw comes up empty routinely, and the fit currently completes with no splits and predicts the bias for every row, with nothing said.

In `init_core` an unsupported target eltype is reported the same way, then execution continues to `K = length(target_levels)` with `target_levels` still `nothing`. The helpful message is only a log line and the exception the user actually sees is unrelated:

```
[ Error: Invalid target eltype: Float64
MethodError: no method matching length(::Nothing)
```

This also masks the clearer single-level-target error added in #349 two lines further down.

The two in `fit-utils.jl` are unreachable through the table API, since features are filtered to `Union{Real,CategoricalValue}` on auto-detection and asserted against the same union when passed explicitly. They are converted anyway so the idiom is not copied again.

Adds tests in `test/core.jl` for the empty subsample and the invalid target eltype, and that a normal rowsample is unaffected. On the current code the first throws nothing at all and the second throws `MethodError` rather than `ErrorException`.
