### PR TITLE
Error on a non-positive target for gamma regression

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -30,6 +30,13 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
         !isnothing(offset) && (offset .= logit.(offset))
     elseif L in [Poisson, Gamma, Tweedie]
         @assert eltype(y_train) <: Real
+        if L == Gamma
+            ymin = minimum(y_train)
+            ymin <= 0 && error(
+                "Gamma regression requires a strictly positive target, got a minimum of $ymin. " *
+                "The gamma deviance is undefined at 0."
+            )
+        end
         if y_train isa AbstractVector
             K = 1
             y = T.(y_train)

--- a/test/core.jl
+++ b/test/core.jl
@@ -559,4 +559,36 @@ end
         @test length(EvoTrees.importance(m; feature_names=[:a, :a, :b, :c])) == 4
     end
 
+    @testset "gamma target support" begin
+        rng = Xoshiro(21)
+        x = rand(rng, 200, 3)
+        ypos = 1.0 .+ rand(rng, 200)
+
+        m = fit(EvoTreeRegressor(loss=:gamma, nrounds=5); x_train=x, y_train=ypos)
+        @test length(m.trees) == 6
+
+        for bad in (0.0, -1.0)
+            y = copy(ypos)
+            y[7] = bad
+            @test_throws ErrorException fit(
+                EvoTreeRegressor(loss=:gamma, nrounds=5); x_train=x, y_train=y
+            )
+        end
+
+        ymat = permutedims(hcat(ypos, ypos .+ 1))
+        m = fit(EvoTreeRegressor(loss=:gamma, nrounds=5); x_train=x, y_train=ymat)
+        @test length(m.trees) == 6
+        ymat[2, 5] = 0.0
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(loss=:gamma, nrounds=5); x_train=x, y_train=ymat
+        )
+
+        yzero = copy(ypos)
+        yzero[7] = 0.0
+        for loss in (:poisson, :tweedie)
+            m = fit(EvoTreeRegressor(loss=loss, nrounds=5); x_train=x, y_train=yzero)
+            @test length(m.trees) == 6
+        end
+    end
+
 end


### PR DESCRIPTION
Closes #354.

`loss=:gamma` accepts a target containing zeros and then logs `Inf` for every round, so early stopping sees no improvement from the first check and training stops as soon as `early_stopping_rounds` is reached. A negative target is worse, it trains all the way through and returns a model fitted on a deviance that is not defined for that data. Neither case says anything to the user.

On main:

```julia
using EvoTrees, Random
Random.seed!(1)
x = rand(1_000, 5)
y = 1.0 .+ 5.0 .* rand(1_000)
y[rand(1_000) .< 0.10] .= 0.0

config = EvoTreeRegressor(loss=:gamma, metric=:gamma, nrounds=30, eta=0.1,
                          early_stopping_rounds=5)
m = EvoTrees.fit(config; x_train=x, y_train=y, x_eval=x, y_eval=y, verbosity=0)
```

```
nrounds   = 5
best_iter = 0
metrics   = [Inf, Inf, Inf, Inf, Inf, Inf]
```

I asked in #354 whether you would rather error or warn and did not get to it before picking one, so I went with erroring, since that matches how `LogLoss` already validates its target range in `_init_target` and the direction of #349 and #363. Say the word if you want a warning instead and I will swap it.

The check sits in `_init_target`, so both the CPU and GPU paths pick it up. It is scoped to Gamma, `poisson` and `tweedie` are both defined at 0 and keep working on the same target. Validation is on the training target only, matching what `LogLoss` does, so a zero in an eval-only target is still not caught.

Tests in `test/core.jl` next to the existing target-level checks: a positive vector and a positive matrix target still fit, a zero and a negative in a vector target both throw, a zero in a matrix target throws, and poisson and tweedie still fit the zero-containing target. Reverting the source change fails 3 of the 7, and the full suite is green at 629 of 629.
