### PR TITLE
Validate L2, bagging_size and early_stopping_rounds

### DIFF
--- a/src/learners.jl
+++ b/src/learners.jl
@@ -525,8 +525,11 @@ function check_args(args::Dict{Symbol,Any})
     check_parameter(Int, args[:nrounds], 0, typemax(Int), :nrounds)
     check_parameter(Int, args[:max_depth], 1, typemax(Int), :max_depth)
     check_parameter(Int, args[:nbins], 2, 255, :nbins)
+    check_parameter(Int, args[:bagging_size], 1, typemax(Int), :bagging_size)
+    check_parameter(Int, args[:early_stopping_rounds], 0, typemax(Int), :early_stopping_rounds)
 
     # check positive float parameters
+    check_parameter(Float64, args[:L2], zero(Float64), typemax(Float64), :L2)
     check_parameter(Float64, args[:lambda], zero(Float64), typemax(Float64), :lambda)
     check_parameter(Float64, args[:gamma], zero(Float64), typemax(Float64), :gamma)
     check_parameter(Float64, args[:min_weight], zero(Float64), typemax(Float64), :min_weight)
@@ -563,8 +566,11 @@ function check_args(model::EvoTypes)
     check_parameter(Int, model.max_depth, 1, typemax(Int), :max_depth)
     check_parameter(Int, model.nrounds, 0, typemax(Int), :nrounds)
     check_parameter(Int, model.nbins, 2, 255, :nbins)
+    check_parameter(Int, model.bagging_size, 1, typemax(Int), :bagging_size)
+    check_parameter(Int, model.early_stopping_rounds, 0, typemax(Int), :early_stopping_rounds)
 
     # check positive float parameters
+    check_parameter(Float64, model.L2, zero(Float64), typemax(Float64), :L2)
     check_parameter(Float64, model.lambda, zero(Float64), typemax(Float64), :lambda)
     check_parameter(Float64, model.gamma, zero(Float64), typemax(Float64), :gamma)
     check_parameter(Float64, model.min_weight, zero(Float64), typemax(Float64), :min_weight)

--- a/test/core.jl
+++ b/test/core.jl
@@ -450,9 +450,11 @@ end
     # Check the implemented parameters on construction
     @testset "check_args all for EvoTreeRegressor" begin
         for (key, vals_to_test) in zip(
-            [:nrounds, :max_depth, :nbins, :lambda, :gamma, :min_weight, :alpha, :rowsample, :colsample, :eta],
+            [:nrounds, :max_depth, :nbins, :lambda, :gamma, :min_weight, :alpha, :rowsample, :colsample, :eta,
+                :L2, :bagging_size, :early_stopping_rounds],
             [[-1, 1.5], [0, 1.5], [1, 256, 100.5], [-eps(Float64)], [-eps(Float64)], [-eps(Float64)],
-                [-0.1, 1.1], [0.0f0, 1.1f0], [0.0, 1.1], [-eps(Float64)]])
+                [-0.1, 1.1], [0.0f0, 1.1f0], [0.0, 1.1], [-eps(Float64)],
+                [-eps(Float64)], [0, -1, 1.5], [-1, 1.5]])
             for val in vals_to_test
                 @test_throws Exception EvoTreeRegressor(; zip([key], [val])...)
             end
@@ -465,6 +467,39 @@ end
         @test_throws Exception EvoTreeRegressor(loss=:multiquantile, alphas=[0.5, 0.5])
         config = EvoTreeRegressor(loss=:multiquantile, alphas=[0.5], nrounds=1)
         @test check_args(config) === nothing
+    end
+
+    @testset "check_args L2 and bagging_size" begin
+        # Both used to be accepted unvalidated. A negative `L2` lands in the leaf denominator
+        # and takes every prediction to NaN; a `bagging_size` below 1 makes the per-round loop
+        # an empty range, so no trees are grown and the fit reports success anyway.
+        seed!(7)
+        x = rand(200, 3)
+        y = 2 .* x[:, 1] .+ 0.2 .* randn(200)
+
+        @test_throws Exception EvoTreeRegressor(L2=-100.0)
+        @test_throws Exception EvoTreeRegressor(bagging_size=0)
+        @test_throws Exception EvoTreeRegressor(early_stopping_rounds=-1)
+
+        # `L2` is the sibling of `lambda`, which was already bounded below at zero.
+        @test EvoTreeRegressor(L2=0.0) isa EvoTreeRegressor
+        @test EvoTreeRegressor(bagging_size=1) isa EvoTreeRegressor
+        @test EvoTreeRegressor(early_stopping_rounds=0) isa EvoTreeRegressor
+
+        # Valid values still train, and every round still grows a tree.
+        m = fit(EvoTreeRegressor(nrounds=10, max_depth=3, bagging_size=2, L2=1.0);
+            x_train=x, y_train=y, verbosity=0)
+        @test length(m.trees) - 1 == 20
+        @test all(isfinite, predict(m, x))
+
+        # Mutating a fitted config is the path MLJ tuning takes, so the second `check_args`
+        # method must reject the same values.
+        config = EvoTreeRegressor(nrounds=5)
+        config.L2 = -1.0
+        @test_throws Exception check_args(config)
+        config = EvoTreeRegressor(nrounds=5)
+        config.bagging_size = 0
+        @test_throws Exception check_args(config)
     end
 
     # Test all EvoTypes that they have *some* checks in place


### PR DESCRIPTION
`check_args` validates 13 of the 19 tunable parameters. Two of the gaps are reachable and fail silently rather than erroring.

`L2` and `lambda` are both regularisers landing in the same leaf denominator, but only `lambda` is checked against zero. Sweeping `L2` on a 2000 row regression, 10 rounds, depth 4:

```
L2 = -0.5   finite, rmse 0.3169      L2 = -10     ALL NaN
L2 = -5.0   finite, rmse 0.3165      L2 = -100    ALL NaN
```

`fit` returns normally and reports its full complement of trees, and every prediction is NaN. The mechanism is that `max(ϵ, ...)` in the leaf denominator exists to stop a small positive value exploding, and does not stop a negative one: once `hessian + L2` goes negative the guard clamps it to `eps`, so the leaf value becomes the gradient divided by eps, which diverges. The exact threshold is data dependent, which is why a small negative looks harmless.

`bagging_size` is unchecked and used as `for _ in 1:params.bagging_size` in `grow_evotree!`. `1:0` and `1:-1` are empty ranges, so the whole per-round body is skipped:

```
bagging_size =  1   ->  20 trees grown of 20 requested
bagging_size =  0   ->   0 trees grown of 20 requested
bagging_size = -5   ->   0 trees grown of 20 requested
```

The call returns a model that predicts the bias for every row and raises nothing. Both also reach the MLJ path, since the second `check_args` method carries the same gaps and is the one used after mutation when tuning.

Adds the three missing `check_parameter` calls to both methods, in the existing style: `L2` bounded below at zero like `lambda`, `bagging_size` at 1, `early_stopping_rounds` at 0.

Tests extend the existing parameter sweep to the three, check that valid values still construct and train (`nrounds=10, bagging_size=2` giving 20 trees, which is the property `bagging_size=0` silently violated), and cover the `check_args(model)` method separately by mutating a fitted config, since that is the path tuning takes. Nine assertions fail on current main.
