### PR TITLE
Check the column count of a matrix against the model's features

### DIFF
--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -64,6 +64,11 @@ end
 Transform feature data into a UInt8 binarized matrix.
 """
 function binarize(X::AbstractMatrix; feature_names, edges)
+    size(X, 2) == length(feature_names) || error(
+        "Data has $(size(X, 2)) columns but the model was trained on " *
+        "$(length(feature_names)) features. A matrix is matched by position, so it must " *
+        "carry the same features, in the same order, as the training data."
+    )
     x_bin = zeros(UInt8, size(X))
     @threads for j in axes(X, 2)
         x_bin[:, j] .= searchsortedfirst.(Ref(edges[j]), view(X, :, j))

--- a/test/missings.jl
+++ b/test/missings.jl
@@ -121,3 +121,36 @@ end
 
 end
 
+@testset "Matrix - predict column count" begin
+
+    # A matrix carries no names, so it is matched by position. `binarize` sized the bin
+    # matrix from the input while `predict!` indexed it by the model's feature ids under
+    # `@inbounds`, so a short matrix read past the end of the allocation and returned
+    # whatever it found. Training already asserts this invariant at fit; predict did not.
+    seed!(11)
+    x = rand(400, 4)
+    y = 5 .* x[:, 1] .+ 2 .* x[:, 2] .+ 0.1 .* randn(400)
+    m = fit(EvoTreeRegressor(nrounds=10, max_depth=4); x_train=x, y_train=y, verbosity=0)
+
+    for ncol in (1, 2, 3)
+        @test_throws ErrorException predict(m, x[:, 1:ncol])
+    end
+    @test_throws ErrorException predict(m, hcat(x, rand(400)))
+
+    # The correct shape still works, and is unaffected.
+    @test length(predict(m, x)) == 400
+
+    # Eval data goes through the same path, so a mismatched `x_eval` is caught too.
+    @test_throws ErrorException fit(
+        EvoTreeRegressor(nrounds=5, max_depth=3, metric=:mse);
+        x_train=x, y_train=y, x_eval=x[:, 1:3], y_eval=y, verbosity=0)
+
+    # The message names both counts, since the failure is otherwise hard to place.
+    msg = try
+        predict(m, x[:, 1:3])
+        ""
+    catch e
+        sprint(showerror, e)
+    end
+    @test occursin("3 columns", msg) && occursin("4 features", msg)
+end


### PR DESCRIPTION
`predict` on a matrix with fewer columns than the model was trained on reads past the end of the bin matrix and returns a number.

`binarize` sizes the bin matrix from the input, and `predict!` then indexes it by the model's feature ids under `@inbounds`, so `feat = 4` against an `n x 3` matrix reads at `i + 3n`. Same call, two invocations, model trained on 4 features:

```
default (@inbounds active):   no error, pred[1] = 2.51694
--check-bounds=yes:           BoundsError: 3000x3 Matrix{UInt8} at index [299, 4]
```

At three columns it also looks fine, rmse 0.12001 against a correct 0.11999, so nothing in the output suggests a problem.

Every call site already passes `feature_names` and the matrix method never reads it, iterating `axes(X, 2)` instead. The check uses it, and matches the assertion already made on `x_train` at `src/init.jl:335`. Swapped columns still predict silently, which is unavoidable for a bare matrix.

Tests cover 1, 2, 3 and 5 columns, a mismatched `x_eval`, and the message naming both counts. Six fail on current main.
