### PR TITLE
Validate eval data the way training data is validated

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -18,6 +18,22 @@ function eval_levelcode(y_eval, target_levels)
     return UInt32.(idx)
 end
 
+# Mirrors the assertion training makes on its own inputs in `src/init.jl`. Eval data was
+# accepted unchecked, so a short weight vector silently scored a subset of the eval set and a
+# weight vector summing to zero produced a NaN or Inf metric.
+function check_eval_data(y, w, nobs)
+    size(y, ndims(y)) == nobs || error(
+        "`y_eval` has $(size(y, ndims(y))) observations but the evaluation features have " *
+        "$(nobs). They must match."
+    )
+    length(w) == nobs || error(
+        "`w_eval` has length $(length(w)) but the evaluation features have $(nobs) " *
+        "observations. Each row needs exactly one weight."
+    )
+    minimum(w) > 0 || error("`w_eval` must be strictly positive.")
+    return nothing
+end
+
 struct CallBack{B,P,Y,C,D,K}
     feval::Function
     x_bin::B
@@ -59,6 +75,7 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(deval, _weight_name))
+    check_eval_data(y, w, nobs)
     metric_kwargs = hasproperty(params, :alpha) ? (alpha=T(params.alpha),) : (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)
@@ -100,6 +117,7 @@ function CallBack(
     feval = metric_dict[params.metric]
     V = device_array_type(device)
     w = isnothing(w_eval) ? device_ones(device, T, size(x_eval, 1)) : V{T}(w_eval)
+    check_eval_data(y, w, size(x_eval, 1))
     metric_kwargs = hasproperty(params, :alpha) ? (alpha=T(params.alpha),) : (;)
     if params.metric == :multiquantile
         alphas_eval = T.(params.alphas)

--- a/test/core.jl
+++ b/test/core.jl
@@ -514,6 +514,30 @@ end
         end
     end
 
+    @testset "eval data validation" begin
+        # Training checks its own inputs; the eval path did not, so a short weight vector
+        # silently scored a subset of the eval set and reported it as the whole, and a
+        # weight vector summing to zero produced a NaN metric.
+        rng = Xoshiro(13)
+        x = rand(rng, 300, 3)
+        y = 2 .* x[:, 1] .+ 0.2 .* randn(rng, 300)
+        cfg = EvoTreeRegressor(nrounds=5, max_depth=3, metric=:mse)
+        base = (x_train=x, y_train=y, x_eval=x, y_eval=y)
+
+        @test_throws ErrorException fit(cfg; base..., w_eval=ones(150), verbosity=0)
+        @test_throws ErrorException fit(cfg; base..., w_eval=ones(600), verbosity=0)
+        @test_throws ErrorException fit(cfg; base..., w_eval=zeros(300), verbosity=0)
+        @test_throws ErrorException fit(cfg; base..., w_eval=fill(-1.0, 300), verbosity=0)
+        @test_throws ErrorException fit(
+            cfg; x_train=x, y_train=y, x_eval=x, y_eval=y[1:150], verbosity=0)
+
+        # Valid eval data is unaffected, weighted or not.
+        m = fit(cfg; base..., verbosity=0)
+        @test isfinite(m.info[:logger][:metrics][end])
+        mw = fit(cfg; base..., w_eval=(0.5 .+ rand(rng, 300)), verbosity=0)
+        @test isfinite(mw.info[:logger][:metrics][end])
+    end
+
     @testset "classifier target levels" begin
         rng = Xoshiro(7)
         x = rand(rng, 40, 3)


### PR DESCRIPTION
Eval data is accepted without any of the checks training makes on its own inputs, so a malformed weight or target vector produces a wrong metric rather than an error.

`init_core` asserts `size(y, ndims(y)) == length(w) && minimum(w) > 0` on the training data. `CallBack` asserts nothing. Measured on a 300 row eval set with `metric=:mse`:

```
w_eval length 150 of 300   no error, scores half the set and reports it as the whole
w_eval all zero            no error, metric NaN
w_eval all negative        no error, metric looks plausible and means nothing
y_eval length 150 of 300   raw BoundsError
```

The zero and negative cases land in the `sum(eval) / sum(w)` denominator. The short case is the quieter one: `_eval_metric` iterates `eachindex(w)` and `eval` is `similar(w)`, so a short weight vector silently shrinks the evaluation set instead of reading out of bounds.

Adds `check_eval_data`, called from both `CallBack` constructors, mirroring the training assertion but naming the counts in the message. The `eachindex(w)` and `eachindex(y)` mix in `src/metrics.jl` is left alone, since with the lengths checked the two are equivalent.

Tests cover short, long, zero and negative weights, a short `y_eval`, and that valid weighted and unweighted eval data still fit. Five fail on current main.
