### PR TITLE
Ranking: group support, per-query NDCG and a LambdaRank objective

### DIFF
--- a/benchmarks/Yahoo-LTRC.jl
+++ b/benchmarks/Yahoo-LTRC.jl
@@ -1,4 +1,3 @@
-using Revise
 using CSV
 using DataFrames
 using EvoTrees
@@ -6,7 +5,6 @@ using StatsBase: sample, tiedrank
 using Statistics
 using Random: seed!
 using ReadLIBSVM
-# using GLMakie
 
 # data is C14 - Yahoo! Learning to Rank Challenge
 # data can be obtained though a request to https://webscope.sandbox.yahoo.com/
@@ -20,38 +18,22 @@ function read_libsvm_aws(file::String; has_query=false, aws_config=AWSConfig())
     return read_libsvm(raw; has_query)
 end
 
-function ndcg(p, y, k=10)
-    k = min(k, length(p))
-    p_order = partialsortperm(p, 1:k, rev=true)
-    y_order = partialsortperm(y, 1:k, rev=true)
-    _y = y[p_order]
-    gains = 2 .^ _y .- 1
-    discounts = log2.((1:k) .+ 1)
-    ndcg = sum(gains ./ discounts)
-
-    y_order = partialsortperm(y, 1:k, rev=true)
-    _y = y[y_order]
-    gains = 2 .^ _y .- 1
-    discounts = log2.((1:k) .+ 1)
-    idcg = sum(gains ./ discounts)
-
-    return idcg == 0 ? 1.0 : ndcg / idcg
+# Test-set NDCG through the package's own metric, so the reported figure is the same
+# quantity early stopping selects on rather than a second implementation.
+function ndcg_test(m, x, y, q; k=10)
+    p = EvoTrees.predict(m, x)
+    gi = EvoTrees.build_group_index(q, length(q), "q")
+    w = ones(Float32, length(y))
+    EvoTrees.ndcg(reshape(Float32.(p), 1, :), Float32.(y), w, Float32[]; group=gi, ndcg_k=k)
 end
-
-p = [6, 5, 4, 3, 2, 1, 0, -1] .+ 100
-y = [3, 2, 3, 0, 1, 2, 3, 2]
-ndcg(p, y, 6)
 
 @time dtrain = read_libsvm_aws("share/data/yahoo-ltrc/set1.train.txt"; has_query=true, aws_config)
 @time deval = read_libsvm_aws("share/data/yahoo-ltrc/set1.valid.txt"; has_query=true, aws_config)
 @time dtest = read_libsvm_aws("share/data/yahoo-ltrc/set1.test.txt"; has_query=true, aws_config)
 
 colsums_train = map(sum, eachcol(dtrain[:x]))
-# colsums_eval = map(sum, eachcol(deval[:x]))
 colsums_test = map(sum, eachcol(deval[:x]))
 
-sum(colsums_train .== 0)
-sum(colsums_test .== 0)
 @assert all((colsums_train .== 0) .== (colsums_test .== 0))
 drop_cols = colsums_train .== 0
 
@@ -59,37 +41,25 @@ x_train = dtrain[:x][:, .!drop_cols]
 x_eval = deval[:x][:, .!drop_cols]
 x_test = dtest[:x][:, .!drop_cols]
 
-# x_train_miss = x_train .== 0
-# x_eval_miss = x_eval .== 0
-# x_test_miss = x_test .== 0
-
-# x_train[x_train.==0] .= 0.5
-# x_eval[x_eval.==0] .= 0.5
-# x_test[x_test.==0] .= 0.5
-
-# x_train = hcat(x_train, x_train_miss)
-# x_eval = hcat(x_eval, x_eval_miss)
-# x_test = hcat(x_test, x_test_miss)
-
 q_train = dtrain[:q]
 q_eval = deval[:q]
 q_test = dtest[:q]
-
-y_train = dtrain[:y];
-y_eval = deval[:y];
-y_test = dtest[:y];
-
-#####################################
-# mse regression
-#####################################
 
 y_train = dtrain[:y]
 y_eval = deval[:y]
 y_test = dtest[:y]
 
+const NDCG_K = 10
+
+#####################################
+# mse regression
+#####################################
 config = EvoTreeRegressor(
     nrounds=6000,
     loss=:mse,
+    metric=:ndcg,
+    ndcg_k=NDCG_K,
+    early_stopping_rounds=200,
     eta=0.02,
     nbins=64,
     max_depth=11,
@@ -97,37 +67,30 @@ config = EvoTreeRegressor(
     colsample=0.9,
 )
 
-# @time m = fit_evotree(config; x_train, y_train, print_every_n=25);
-@time m_mse, logger_mse = fit_evotree(
+@time m_mse = EvoTrees.fit(
     config;
-    x_train=x_train,
-    y_train=y_train,
-    x_eval=x_eval,
-    y_eval=y_eval,
-    early_stopping_rounds=200,
+    x_train, y_train, group_train=q_train,
+    x_eval, y_eval, group_eval=q_eval,
     print_every_n=50,
-    metric=:mse,
-    return_logger=true
-);
+)
 
-p_test = m_mse(x_test);
-test_df = DataFrame(p=p_test, y=y_test, q=q_test)
-test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
-ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
+p_test = EvoTrees.predict(m_mse, x_test)
 @info "MSE - test data - MSE model" mean((p_test .- y_test) .^ 2)
-@info "NDCG - test data - MSE model" ndcg_test
+@info "NDCG - test data - MSE model" round(ndcg_test(m_mse, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
 
 #####################################
 # logistic regression
 #####################################
+# `:logloss` needs the target in [0, 1], so the NDCG tracked during fitting is computed on
+# the scaled relevance. Ranking is unaffected, but the logged value is not on the same scale
+# as the test figures below, which all use the raw 0-4 relevance.
 max_rank = 4
-y_train = dtrain[:y] ./ max_rank
-y_eval = deval[:y] ./ max_rank
-y_test = dtest[:y] ./ max_rank
-
 config = EvoTreeRegressor(
     nrounds=6000,
     loss=:logloss,
+    metric=:ndcg,
+    ndcg_k=NDCG_K,
+    early_stopping_rounds=200,
     eta=0.01,
     nbins=64,
     max_depth=11,
@@ -135,121 +98,44 @@ config = EvoTreeRegressor(
     colsample=0.9,
 )
 
-@time m_logloss, logger_logloss = fit_evotree(
+@time m_logloss = EvoTrees.fit(
     config;
-    x_train=x_train,
-    y_train=y_train,
-    x_eval=x_eval,
-    y_eval=y_eval,
-    early_stopping_rounds=200,
+    x_train, y_train=y_train ./ max_rank, group_train=q_train,
+    x_eval, y_eval=y_eval ./ max_rank, group_eval=q_eval,
     print_every_n=50,
-    metric=:logloss,
-    return_logger=true
-);
+)
 
-# use the original y since NDCG is scale sensitive
-y_train = dtrain[:y]
-y_eval = deval[:y]
-y_test = dtest[:y]
-
-# p_eval = m(x_eval);
-# eval_df = DataFrame(p = p_eval, y = y_eval, q = q_eval)
-# eval_df_agg = combine(groupby(eval_df, "q"), ["p", "y"] => ndcg => "ndcg")
-# ndcg_eval = mean(eval_df_agg.ndcg)
-
-p_test = m_logloss(x_test);
-test_df = DataFrame(p=p_test, y=y_test, q=q_test)
-test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
-ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
-@info "NDCG - test data - LogLoss model" ndcg_test
+@info "NDCG - test data - LogLoss model" round(ndcg_test(m_logloss, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
 
 #####################################
-# logistic regression on DataFrame
+# lambdarank
 #####################################
-target_name = "y"
-
-df_train = DataFrame(x_train, :auto)
-df_train.y = dtrain[:y] ./ 4
-df_train.q = dtrain[:q]
-
-df_eval = DataFrame(x_eval, :auto)
-df_eval.y = deval[:y] ./ 4
-df_eval.q = deval[:q]
-
-df_test = DataFrame(x_test, :auto)
-df_test.y = dtest[:y] ./ 4
-df_test.q = dtest[:q]
-
-function rank_target_norm(y::AbstractVector)
-    out = similar(y)
-    if minimum(y) == maximum(y)
-        out .= 0.5
-    else
-        out .= (y .- minimum(y)) ./ (maximum(y) - minimum(y))
-    end
-    return out
-end
-
-function percent_rank(x::AbstractVector{T}) where {T}
-    return tiedrank(x) / (length(x) + 1)
-end
-
-feature_names_raw = setdiff(names(df_train), ["y", "q"])
-feature_names_rel = feature_names_raw .* "_rel"
-
-transform!(df_train, feature_names_raw .=> percent_rank .=> feature_names_rel)
-transform!(df_eval, feature_names_raw .=> percent_rank .=> feature_names_rel)
-transform!(df_test, feature_names_raw .=> percent_rank .=> feature_names_rel)
-
-feature_names = setdiff(names(df_train), ["y", "q"])
-
-# df_train = transform!(
-#     groupby(df_train, "q"),
-#     "y" => rank_target_norm => "y")
-
-# df_eval = transform!(
-#     groupby(df_eval, "q"),
-#     "y" => rank_target_norm => "y")
-
-# df_test = transform!(
-#     groupby(df_test, "q"),
-#     "y" => rank_target_norm => "y")
-
-minimum(df_eval.y)
-maximum(df_eval.y)
-
 config = EvoTreeRegressor(
     nrounds=6000,
-    loss=:logloss,
-    eta=0.01,
+    loss=:lambdarank,
+    metric=:ndcg,
+    ndcg_k=NDCG_K,
+    early_stopping_rounds=200,
+    eta=0.02,
     nbins=64,
     max_depth=11,
     rowsample=0.9,
     colsample=0.9,
 )
 
-@time m_logloss_df, logger_logloss_df = fit_evotree(
-    config,
-    df_train;
-    target_name,
-    fnames=feature_names_raw,
-    deval=df_eval,
-    early_stopping_rounds=200,
+@time m_lambda = EvoTrees.fit(
+    config;
+    x_train, y_train, group_train=q_train,
+    x_eval, y_eval, group_eval=q_eval,
     print_every_n=50,
-    metric=:logloss,
-    return_logger=true
-);
+)
 
-m_logloss_df.info
-p_test_df = m_logloss_df(df_test);
-# p_test_mat = m_logloss_df(x_test);
+@info "NDCG - test data - LambdaRank model" round(ndcg_test(m_lambda, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
 
-EvoTrees.importance(m_logloss_df)
-
-p_test = m_logloss_df(df_test);
-test_df = DataFrame(p=p_test, y=dtest[:y], q=dtest[:q])
-test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
-ndcg_test = mean(test_df_agg.ndcg)
-# ndcg_test = 0.8022558972243291
-# ndcg_test = 0.8020754563069513
-@info "NDCG - test data - LogLoss DF model" ndcg_test
+#####################################
+# summary
+#####################################
+for (name, m) in (("mse", m_mse), ("logloss", m_logloss), ("lambdarank", m_lambda))
+    @info name trees = length(m.trees) - 1 best_iter = m.info[:logger][:best_iter] ndcg = round(
+        ndcg_test(m, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
+end

--- a/benchmarks/Yahoo-LTRC.jl
+++ b/benchmarks/Yahoo-LTRC.jl
@@ -1,3 +1,4 @@
+using Revise
 using CSV
 using DataFrames
 using EvoTrees
@@ -5,6 +6,7 @@ using StatsBase: sample, tiedrank
 using Statistics
 using Random: seed!
 using ReadLIBSVM
+# using GLMakie
 
 # data is C14 - Yahoo! Learning to Rank Challenge
 # data can be obtained though a request to https://webscope.sandbox.yahoo.com/
@@ -18,22 +20,38 @@ function read_libsvm_aws(file::String; has_query=false, aws_config=AWSConfig())
     return read_libsvm(raw; has_query)
 end
 
-# Test-set NDCG through the package's own metric, so the reported figure is the same
-# quantity early stopping selects on rather than a second implementation.
-function ndcg_test(m, x, y, q; k=10)
-    p = EvoTrees.predict(m, x)
-    gi = EvoTrees.build_group_index(q, length(q), "q")
-    w = ones(Float32, length(y))
-    EvoTrees.ndcg(reshape(Float32.(p), 1, :), Float32.(y), w, Float32[]; group=gi, ndcg_k=k)
+function ndcg(p, y, k=10)
+    k = min(k, length(p))
+    p_order = partialsortperm(p, 1:k, rev=true)
+    y_order = partialsortperm(y, 1:k, rev=true)
+    _y = y[p_order]
+    gains = 2 .^ _y .- 1
+    discounts = log2.((1:k) .+ 1)
+    ndcg = sum(gains ./ discounts)
+
+    y_order = partialsortperm(y, 1:k, rev=true)
+    _y = y[y_order]
+    gains = 2 .^ _y .- 1
+    discounts = log2.((1:k) .+ 1)
+    idcg = sum(gains ./ discounts)
+
+    return idcg == 0 ? 1.0 : ndcg / idcg
 end
+
+p = [6, 5, 4, 3, 2, 1, 0, -1] .+ 100
+y = [3, 2, 3, 0, 1, 2, 3, 2]
+ndcg(p, y, 6)
 
 @time dtrain = read_libsvm_aws("share/data/yahoo-ltrc/set1.train.txt"; has_query=true, aws_config)
 @time deval = read_libsvm_aws("share/data/yahoo-ltrc/set1.valid.txt"; has_query=true, aws_config)
 @time dtest = read_libsvm_aws("share/data/yahoo-ltrc/set1.test.txt"; has_query=true, aws_config)
 
 colsums_train = map(sum, eachcol(dtrain[:x]))
+# colsums_eval = map(sum, eachcol(deval[:x]))
 colsums_test = map(sum, eachcol(deval[:x]))
 
+sum(colsums_train .== 0)
+sum(colsums_test .== 0)
 @assert all((colsums_train .== 0) .== (colsums_test .== 0))
 drop_cols = colsums_train .== 0
 
@@ -41,24 +59,38 @@ x_train = dtrain[:x][:, .!drop_cols]
 x_eval = deval[:x][:, .!drop_cols]
 x_test = dtest[:x][:, .!drop_cols]
 
+# x_train_miss = x_train .== 0
+# x_eval_miss = x_eval .== 0
+# x_test_miss = x_test .== 0
+
+# x_train[x_train.==0] .= 0.5
+# x_eval[x_eval.==0] .= 0.5
+# x_test[x_test.==0] .= 0.5
+
+# x_train = hcat(x_train, x_train_miss)
+# x_eval = hcat(x_eval, x_eval_miss)
+# x_test = hcat(x_test, x_test_miss)
+
 q_train = dtrain[:q]
 q_eval = deval[:q]
 q_test = dtest[:q]
+
+y_train = dtrain[:y];
+y_eval = deval[:y];
+y_test = dtest[:y];
+
+#####################################
+# mse regression
+#####################################
 
 y_train = dtrain[:y]
 y_eval = deval[:y]
 y_test = dtest[:y]
 
-const NDCG_K = 10
-
-#####################################
-# mse regression
-#####################################
 config = EvoTreeRegressor(
     nrounds=6000,
     loss=:mse,
-    metric=:ndcg,
-    ndcg_k=NDCG_K,
+    metric=:mse,
     early_stopping_rounds=200,
     eta=0.02,
     nbins=64,
@@ -67,29 +99,35 @@ config = EvoTreeRegressor(
     colsample=0.9,
 )
 
+# @time m = fit_evotree(config; x_train, y_train, print_every_n=25);
 @time m_mse = EvoTrees.fit(
     config;
-    x_train, y_train, group_train=q_train,
-    x_eval, y_eval, group_eval=q_eval,
+    x_train=x_train,
+    y_train=y_train,
+    x_eval=x_eval,
+    y_eval=y_eval,
     print_every_n=50,
-)
+);
 
-p_test = EvoTrees.predict(m_mse, x_test)
+p_test = m_mse(x_test);
+test_df = DataFrame(p=p_test, y=y_test, q=q_test)
+test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
+ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
 @info "MSE - test data - MSE model" mean((p_test .- y_test) .^ 2)
-@info "NDCG - test data - MSE model" round(ndcg_test(m_mse, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
+@info "NDCG - test data - MSE model" ndcg_test
 
 #####################################
 # logistic regression
 #####################################
-# `:logloss` needs the target in [0, 1], so the NDCG tracked during fitting is computed on
-# the scaled relevance. Ranking is unaffected, but the logged value is not on the same scale
-# as the test figures below, which all use the raw 0-4 relevance.
 max_rank = 4
+y_train = dtrain[:y] ./ max_rank
+y_eval = deval[:y] ./ max_rank
+y_test = dtest[:y] ./ max_rank
+
 config = EvoTreeRegressor(
     nrounds=6000,
     loss=:logloss,
-    metric=:ndcg,
-    ndcg_k=NDCG_K,
+    metric=:logloss,
     early_stopping_rounds=200,
     eta=0.01,
     nbins=64,
@@ -100,21 +138,131 @@ config = EvoTreeRegressor(
 
 @time m_logloss = EvoTrees.fit(
     config;
-    x_train, y_train=y_train ./ max_rank, group_train=q_train,
-    x_eval, y_eval=y_eval ./ max_rank, group_eval=q_eval,
+    x_train=x_train,
+    y_train=y_train,
+    x_eval=x_eval,
+    y_eval=y_eval,
     print_every_n=50,
+);
+
+# use the original y since NDCG is scale sensitive
+y_train = dtrain[:y]
+y_eval = deval[:y]
+y_test = dtest[:y]
+
+# p_eval = m(x_eval);
+# eval_df = DataFrame(p = p_eval, y = y_eval, q = q_eval)
+# eval_df_agg = combine(groupby(eval_df, "q"), ["p", "y"] => ndcg => "ndcg")
+# ndcg_eval = mean(eval_df_agg.ndcg)
+
+p_test = m_logloss(x_test);
+test_df = DataFrame(p=p_test, y=y_test, q=q_test)
+test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
+ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
+@info "NDCG - test data - LogLoss model" ndcg_test
+
+#####################################
+# logistic regression on DataFrame
+#####################################
+target_name = "y"
+
+df_train = DataFrame(x_train, :auto)
+df_train.y = dtrain[:y] ./ 4
+df_train.q = dtrain[:q]
+
+df_eval = DataFrame(x_eval, :auto)
+df_eval.y = deval[:y] ./ 4
+df_eval.q = deval[:q]
+
+df_test = DataFrame(x_test, :auto)
+df_test.y = dtest[:y] ./ 4
+df_test.q = dtest[:q]
+
+function rank_target_norm(y::AbstractVector)
+    out = similar(y)
+    if minimum(y) == maximum(y)
+        out .= 0.5
+    else
+        out .= (y .- minimum(y)) ./ (maximum(y) - minimum(y))
+    end
+    return out
+end
+
+function percent_rank(x::AbstractVector{T}) where {T}
+    return tiedrank(x) / (length(x) + 1)
+end
+
+feature_names_raw = setdiff(names(df_train), ["y", "q"])
+feature_names_rel = feature_names_raw .* "_rel"
+
+transform!(df_train, feature_names_raw .=> percent_rank .=> feature_names_rel)
+transform!(df_eval, feature_names_raw .=> percent_rank .=> feature_names_rel)
+transform!(df_test, feature_names_raw .=> percent_rank .=> feature_names_rel)
+
+feature_names = setdiff(names(df_train), ["y", "q"])
+
+# df_train = transform!(
+#     groupby(df_train, "q"),
+#     "y" => rank_target_norm => "y")
+
+# df_eval = transform!(
+#     groupby(df_eval, "q"),
+#     "y" => rank_target_norm => "y")
+
+# df_test = transform!(
+#     groupby(df_test, "q"),
+#     "y" => rank_target_norm => "y")
+
+minimum(df_eval.y)
+maximum(df_eval.y)
+
+config = EvoTreeRegressor(
+    nrounds=6000,
+    loss=:logloss,
+    metric=:logloss,
+    early_stopping_rounds=200,
+    eta=0.01,
+    nbins=64,
+    max_depth=11,
+    rowsample=0.9,
+    colsample=0.9,
 )
 
-@info "NDCG - test data - LogLoss model" round(ndcg_test(m_logloss, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
+@time m_logloss_df = EvoTrees.fit(
+    config,
+    df_train;
+    target_name,
+    feature_names=feature_names_raw,
+    deval=df_eval,
+    print_every_n=50,
+);
+
+m_logloss_df.info
+p_test_df = m_logloss_df(df_test);
+# p_test_mat = m_logloss_df(x_test);
+
+EvoTrees.importance(m_logloss_df)
+
+p_test = m_logloss_df(df_test);
+test_df = DataFrame(p=p_test, y=dtest[:y], q=dtest[:q])
+test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
+ndcg_test = mean(test_df_agg.ndcg)
+# ndcg_test = 0.8022558972243291
+# ndcg_test = 0.8020754563069513
+@info "NDCG - test data - LogLoss DF model" ndcg_test
 
 #####################################
 # lambdarank
 #####################################
+y_train = dtrain[:y]
+y_eval = deval[:y]
+y_test = dtest[:y]
+
 config = EvoTreeRegressor(
     nrounds=6000,
     loss=:lambdarank,
     metric=:ndcg,
-    ndcg_k=NDCG_K,
+    ndcg_k=10,
     early_stopping_rounds=200,
     eta=0.02,
     nbins=64,
@@ -123,19 +271,19 @@ config = EvoTreeRegressor(
     colsample=0.9,
 )
 
-@time m_lambda = EvoTrees.fit(
+@time m_lambdarank = EvoTrees.fit(
     config;
-    x_train, y_train, group_train=q_train,
-    x_eval, y_eval, group_eval=q_eval,
+    x_train=x_train,
+    y_train=y_train,
+    group_train=q_train,
+    x_eval=x_eval,
+    y_eval=y_eval,
+    group_eval=q_eval,
     print_every_n=50,
-)
+);
 
-@info "NDCG - test data - LambdaRank model" round(ndcg_test(m_lambda, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
-
-#####################################
-# summary
-#####################################
-for (name, m) in (("mse", m_mse), ("logloss", m_logloss), ("lambdarank", m_lambda))
-    @info name trees = length(m.trees) - 1 best_iter = m.info[:logger][:best_iter] ndcg = round(
-        ndcg_test(m, x_test, y_test, q_test; k=NDCG_K), sigdigits=5)
-end
+p_test = m_lambdarank(x_test);
+test_df = DataFrame(p=p_test, y=y_test, q=q_test)
+test_df_agg = combine(groupby(test_df, "q"), ["p", "y"] => ndcg => "ndcg")
+ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
+@info "NDCG - test data - LambdaRank model" ndcg_test

--- a/benchmarks/pythoncall/ranking.jl
+++ b/benchmarks/pythoncall/ranking.jl
@@ -1,3 +1,4 @@
+using CUDA
 using PythonCall
 using CSV
 using DataFrames

--- a/benchmarks/pythoncall/ranking.jl
+++ b/benchmarks/pythoncall/ranking.jl
@@ -1,0 +1,101 @@
+using PythonCall
+using CSV
+using DataFrames
+using Statistics
+using EvoTrees
+using Random: seed!
+
+xgb = pyimport("xgboost")
+np = pyimport("numpy")
+
+nrounds = 200
+T = Float32
+nthreads = Base.Threads.nthreads()
+
+# Ranking cost grows with the number of documents per query, so group size is swept alongside
+# the usual shapes. XGBoost truncates pairs by default, EvoTrees scores every pair.
+group_size_list = [10, 20, 100]
+nobs_list = Int.([1e5, 1e6])
+nfeats_list = [100]
+max_depth_list = [6]
+ndcg_k = 10
+
+device_list = [:cpu, :gpu]
+
+for _device in device_list
+    df = DataFrame()
+    for nobs in nobs_list
+        for nfeats in nfeats_list
+            for max_depth in max_depth_list
+                for group_size in group_size_list
+
+                    @info "device: $_device | nobs: $nobs | nfeats: $nfeats | max_depth: $max_depth | group_size: $group_size | nthreads: $nthreads"
+                    seed!(123)
+                    x_train = rand(T, nobs, nfeats)
+                    y_train = T.(rand(0:4, nobs))
+                    ngroups = nobs ÷ group_size
+                    q_train = UInt32.(repeat(1:ngroups, inner=group_size))
+
+                    _df = DataFrame(
+                        :device => _device,
+                        :nobs => nobs,
+                        :nfeats => nfeats,
+                        :max_depth => max_depth,
+                        :group_size => group_size)
+
+                    # EvoTrees, mse against lambdarank on the same groups
+                    for (name, loss, metric) in ((:mse, :mse, :mae), (:lambdarank, :lambdarank, :ndcg))
+                        params_evo = EvoTreeRegressor(;
+                            loss, metric, nrounds, max_depth, ndcg_k,
+                            eta=0.05, min_weight=1.0, rowsample=0.5, colsample=0.5,
+                            nbins=64, tree_type=:binary, seed=123, device=_device)
+                        EvoTrees.fit(params_evo; x_train, y_train, group_train=q_train,
+                            x_eval=x_train, y_eval=y_train, group_eval=q_train, print_every_n=1000)
+                        t = @elapsed EvoTrees.fit(params_evo; x_train, y_train, group_train=q_train,
+                            x_eval=x_train, y_eval=y_train, group_eval=q_train, print_every_n=1000)
+                        _df[!, Symbol("train_evo_", name)] = [t]
+                    end
+
+                    # XGBoost, reg:squarederror against rank:ndcg on the same groups
+                    x_np = np.array(x_train)
+                    y_np = np.array(y_train)
+                    group_np = np.array(fill(group_size, ngroups))
+                    _dev = _device == :cpu ? "cpu" : "cuda"
+
+                    for (name, objective, metric_xgb) in
+                        ((:mse, "reg:squarederror", "mae"), (:ndcg, "rank:ndcg", "ndcg"))
+
+                        dtrain = xgb.DMatrix(x_np, label=y_np)
+                        objective == "rank:ndcg" && dtrain.set_group(group_np)
+                        params = Dict(
+                            "objective" => objective,
+                            "eval_metric" => pylist([metric_xgb]),
+                            "max_depth" => max_depth,
+                            "eta" => 0.05,
+                            "tree_method" => "hist",
+                            "nthread" => nthreads,
+                            "verbosity" => 0,
+                            "subsample" => 0.5,
+                            "colsample_bytree" => 0.5,
+                            "max_bin" => 64,
+                            "device" => _dev,
+                            "lambdarank_num_pair_per_sample" => ndcg_k,
+                        ) |> pydict
+
+                        xgb.train(params, dtrain, num_boost_round=5,
+                            evals=pylist([(dtrain, "train")]), verbose_eval=1000)
+                        t = @elapsed xgb.train(params, dtrain, num_boost_round=nrounds,
+                            evals=pylist([(dtrain, "train")]), verbose_eval=1000)
+                        _df[!, Symbol("train_xgb_", name)] = [t]
+                    end
+
+                    _df[!, :evo_ndcg_over_mse] = _df.train_evo_lambdarank ./ _df.train_evo_mse
+                    _df[!, :xgb_ndcg_over_mse] = _df.train_xgb_ndcg ./ _df.train_xgb_mse
+                    append!(df, _df)
+                end
+            end
+        end
+    end
+    path = joinpath(@__DIR__, "results", "ranking-$_device.csv")
+    CSV.write(path, df)
+end

--- a/benchmarks/pythoncall/ranking.jl
+++ b/benchmarks/pythoncall/ranking.jl
@@ -13,14 +13,16 @@ T = Float32
 nthreads = Base.Threads.nthreads()
 
 # Ranking cost grows with the number of documents per query, so group size is swept alongside
-# the usual shapes. XGBoost truncates pairs by default, EvoTrees scores every pair.
+# the usual shapes. Neither library is given eval data: a per-round evaluation costs the two
+# very differently, which would otherwise sit on top of the training cost being compared.
 group_size_list = [10, 20, 100]
 nobs_list = Int.([1e5, 1e6])
 nfeats_list = [100]
 max_depth_list = [6]
 ndcg_k = 10
 
-device_list = [:cpu, :gpu]
+device_list = [:cpu]
+# device_list = [:cpu, :gpu]
 
 for _device in device_list
     df = DataFrame()
@@ -50,9 +52,9 @@ for _device in device_list
                             eta=0.05, min_weight=1.0, rowsample=0.5, colsample=0.5,
                             nbins=64, tree_type=:binary, seed=123, device=_device)
                         EvoTrees.fit(params_evo; x_train, y_train, group_train=q_train,
-                            x_eval=x_train, y_eval=y_train, group_eval=q_train, print_every_n=1000)
+                            print_every_n=1000)
                         t = @elapsed EvoTrees.fit(params_evo; x_train, y_train, group_train=q_train,
-                            x_eval=x_train, y_eval=y_train, group_eval=q_train, print_every_n=1000)
+                            print_every_n=1000)
                         _df[!, Symbol("train_evo_", name)] = [t]
                     end
 
@@ -82,10 +84,8 @@ for _device in device_list
                             "lambdarank_num_pair_per_sample" => ndcg_k,
                         ) |> pydict
 
-                        xgb.train(params, dtrain, num_boost_round=5,
-                            evals=pylist([(dtrain, "train")]), verbose_eval=1000)
-                        t = @elapsed xgb.train(params, dtrain, num_boost_round=nrounds,
-                            evals=pylist([(dtrain, "train")]), verbose_eval=1000)
+                        xgb.train(params, dtrain, num_boost_round=5)
+                        t = @elapsed xgb.train(params, dtrain, num_boost_round=nrounds)
                         _df[!, Symbol("train_xgb_", name)] = [t]
                     end
 

--- a/benchmarks/pythoncall/ranking.jl
+++ b/benchmarks/pythoncall/ranking.jl
@@ -21,8 +21,8 @@ nfeats_list = [100]
 max_depth_list = [6]
 ndcg_k = 10
 
-device_list = [:cpu]
-# device_list = [:cpu, :gpu]
+device_list = [:cpu, :gpu]
+# device_list = [:gpu]
 
 for _device in device_list
     df = DataFrame()

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -202,7 +202,12 @@ m = EvoTrees.fit(
 );
 ```
 
-Relevance must be non-negative, since gains are `2^rel - 1`.
+Relevance must be non-negative, since gains are `2^rel - 1`. Cost is quadratic in the size
+of a query, which is not a concern at typical query sizes but is worth knowing if a single
+group is very large.
+
+Groups are passed to `EvoTrees.fit` directly. The MLJ interface has no way to carry them,
+so ranking is not available through it.
 
 Whether this beats the regression approach above depends on the data. It helps most where
 queries differ in how they are graded, since the absolute label level is then query-specific

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -172,7 +172,7 @@ the inferred features:
 m = EvoTrees.fit(config, dtrain; target_name="y", group_name="q", deval)
 ```
 
-Group-aware training is currently CPU only.
+Groups are supported on both CPU and GPU.
 
 ## Logistic regression alternative
 

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -166,10 +166,16 @@ query is never split across the sampled and unsampled sets. This matters because
 the unit NDCG is defined over, and a partial group changes the comparison set.
 
 When fitting from a table, the equivalent is `group_name`, and the column is excluded from
-the inferred features:
+the inferred features. `dtrain` above is the LIBSVM parse result rather than a table, so build
+one from the arrays already extracted:
 
 ```julia
-m = EvoTrees.fit(config, dtrain; target_name="y", group_name="q", deval)
+df_train = DataFrame(x_train, :auto)
+df_train.y, df_train.q = y_train, q_train
+df_eval = DataFrame(x_eval, :auto)
+df_eval.y, df_eval.q = y_eval, q_eval
+
+m = EvoTrees.fit(config, df_train; target_name="y", group_name="q", deval=df_eval)
 ```
 
 Groups are supported on both CPU and GPU.
@@ -197,7 +203,7 @@ tracked:
 
 ```julia
 config = EvoTreeRegressor(loss=:mse, metric=:corr)
-m = EvoTrees.fit(config, dtrain; target_name="y", eval_group_name="q", deval)
+m = EvoTrees.fit(config, df_train; target_name="y", eval_group_name="q", deval=df_eval)
 ```
 
 It defaults to `group_name`, so grouping both sides stays a single argument.

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -123,6 +123,57 @@ ndcg_test = round(mean(test_df_agg.ndcg), sigdigits=5)
 └   ndcg_test = 0.8008
 ```
 
+## Using native group support
+
+The section above computes NDCG after the fact, outside the model. EvoTrees can also be told
+about groups directly, which makes two things available during training.
+
+Pass the query id alongside the features and target. `group_train` and `group_eval` take one
+id per row, and rows sharing an id form a group. Ids need not be contiguous or sorted, so the
+query vectors above can be passed as they are:
+
+```julia
+config = EvoTreeRegressor(
+    nrounds=6000,
+    early_stopping_rounds=200,
+    loss=:mse,
+    eta=0.02,
+    nbins=64,
+    max_depth=11,
+    rowsample=0.9,
+    colsample=0.9,
+    metric=:ndcg,
+    ndcg_k=10,
+)
+
+m = EvoTrees.fit(
+    config;
+    x_train, y_train, group_train=q_train,
+    x_eval, y_eval, group_eval=q_eval,
+    print_every_n=50,
+);
+```
+
+This changes two behaviours.
+
+`metric = :ndcg` computes NDCG within each group and averages over groups, which is the same
+quantity the `groupby` above produces, so early stopping now selects on ranking quality
+rather than on squared error. `ndcg_k` sets the truncation rank, and defaults to scoring the
+full list.
+
+`rowsample` becomes group aware: whole groups are sampled rather than individual rows, so a
+query is never split across the sampled and unsampled sets. This matters because a group is
+the unit NDCG is defined over, and a partial group changes the comparison set.
+
+When fitting from a table, the equivalent is `group_name`, and the column is excluded from
+the inferred features:
+
+```julia
+m = EvoTrees.fit(config, dtrain; target_name="y", group_name="q", deval)
+```
+
+Group-aware training is currently CPU only.
+
 ## Logistic regression alternative
 
 The above regression experiment shows a performance competitive with the results outlined in CatBoost's [ranking benchmarks](https://github.com/catboost/benchmarks/blob/master/ranking/Readme.md#4-results). 

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -174,6 +174,34 @@ m = EvoTrees.fit(config, dtrain; target_name="y", group_name="q", deval)
 
 Groups are supported on both CPU and GPU.
 
+## Weights and grouped metrics
+
+A group's weight is the mean of its rows' weights, so the default of unit weights leaves every
+query equally weighted regardless of how many documents it holds. Giving a query's rows a
+common weight of 2 makes that query count twice one whose rows weigh 1.
+
+Only that group-level weight reaches `:ndcg`. NDCG is defined from the ranking of a group's
+documents, so the spread of weights *within* a group is deliberately ignored, which matches the
+canonical definition and the per-query weights other ranking libraries accept.
+
+Where per-document weights should count, `metric = :corr` scores the weighted Pearson
+correlation between prediction and target within each group and averages over groups. A row's
+own weight enters its group's correlation, and the group weighs by the mean of its rows'
+weights. Groups of fewer than two rows, and groups whose target is constant, carry no signal
+and are left out of the average; a group whose prediction is constant while its target is not
+scores zero.
+
+A grouped metric does not require grouped training. `eval_group_name` sets the group column for
+`deval` alone, so a model can train with ordinary per-row sampling while a group-aware metric is
+tracked:
+
+```julia
+config = EvoTreeRegressor(loss=:mse, metric=:corr)
+m = EvoTrees.fit(config, dtrain; target_name="y", eval_group_name="q", deval)
+```
+
+It defaults to `group_name`, so grouping both sides stays a single argument.
+
 ## Ranking objective
 
 With groups available, `loss=:lambdarank` optimises ranking directly rather than fitting the

--- a/docs/src/tutorials/ranking-LTRC.md
+++ b/docs/src/tutorials/ranking-LTRC.md
@@ -174,6 +174,42 @@ m = EvoTrees.fit(config, dtrain; target_name="y", group_name="q", deval)
 
 Groups are supported on both CPU and GPU.
 
+## Ranking objective
+
+With groups available, `loss=:lambdarank` optimises ranking directly rather than fitting the
+relevance as a regression target. Pairs of documents within a query contribute a pairwise
+cost weighted by the NDCG change that swapping them would cause, so the model is trained on
+within-query order rather than on absolute relevance. `metric` defaults to `:ndcg`.
+
+```julia
+config = EvoTreeRegressor(
+    loss=:lambdarank,
+    ndcg_k=10,
+    nrounds=6000,
+    early_stopping_rounds=200,
+    eta=0.02,
+    nbins=64,
+    max_depth=11,
+    rowsample=0.9,
+    colsample=0.9,
+)
+
+m = EvoTrees.fit(
+    config;
+    x_train, y_train, group_train=q_train,
+    x_eval, y_eval, group_eval=q_eval,
+    print_every_n=50,
+);
+```
+
+Relevance must be non-negative, since gains are `2^rel - 1`.
+
+Whether this beats the regression approach above depends on the data. It helps most where
+queries differ in how they are graded, since the absolute label level is then query-specific
+noise that a regression fit must absorb and a ranking objective can ignore. Where relevance
+is comparable across queries, regression is already a strong baseline, which is what the
+opening of this tutorial reports.
+
 ## Logistic regression alternative
 
 The above regression experiment shows a performance competitive with the results outlined in CatBoost's [ranking benchmarks](https://github.com/catboost/benchmarks/blob/master/ranking/Readme.md#4-results). 

--- a/ext/EvoTreesKernelAbstractionsExt/fit.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/fit.jl
@@ -3,7 +3,9 @@ function EvoTrees.grow_evotree!(m::EvoTree{L,K}, cache::EvoTrees.CacheGPU, param
     EvoTrees.update_grads!(cache.∇, cache.pred, cache.y, L, params)
 
     for _ in 1:params.bagging_size
-        is = EvoTrees.subsample(cache.is_full, cache.mask_cpu, cache.mask_gpu, params.rowsample, cache.rng)
+        is = isnothing(cache.group) ?
+             EvoTrees.subsample(cache.is_full, cache.mask_cpu, cache.mask_gpu, params.rowsample, cache.rng) :
+             EvoTrees.subsample(cache.is_full, cache.mask_cpu, cache.mask_gpu, params.rowsample, cache.rng, cache.group)
 
         js_cpu = Vector{eltype(cache.js)}(undef, length(cache.js))
         EvoTrees.sample!(cache.rng, cache.js_, js_cpu, replace=false, ordered=true)

--- a/ext/EvoTreesKernelAbstractionsExt/fit.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/fit.jl
@@ -1,6 +1,6 @@
 function EvoTrees.grow_evotree!(m::EvoTree{L,K}, cache::EvoTrees.CacheGPU, params::EvoTrees.EvoTypes) where {L,K}
 
-    EvoTrees.update_grads!(cache.∇, cache.pred, cache.y, L, params)
+    EvoTrees.update_grads!(cache.∇, cache.pred, cache.y, L, params, cache.group)
 
     for _ in 1:params.bagging_size
         is = isnothing(cache.group) ?

--- a/ext/EvoTreesKernelAbstractionsExt/init.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/init.jl
@@ -1,4 +1,4 @@
-function EvoTrees.init_core(params::EvoTrees.EvoTypes, device::Type{<:EvoTrees.GPU}, data, feature_names, y_train, w, offset)
+function EvoTrees.init_core(params::EvoTrees.EvoTypes, device::Type{<:EvoTrees.GPU}, data, feature_names, y_train, w, offset, group=nothing)
 
     rng = Xoshiro(params.seed)
     edges, featbins, feattypes = EvoTrees.get_edges(data; feature_names, nbins=params.nbins, rng)
@@ -95,7 +95,20 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, device::Type{<:EvoTrees.G
 
     Y = typeof(y)
     N = typeof(first(nodes))
-    cache = CacheBaseGPU{Y,N}(
+    group_cache = if isnothing(group)
+        nothing
+    else
+        ng = EvoTrees.ngroups(group)
+        GroupCacheGPU(
+            group,
+            _to_device(backend, group.group),
+            zeros(UInt8, ng),
+            KernelAbstractions.zeros(backend, UInt8, ng),
+        )
+    end
+    G = typeof(group_cache)
+
+    cache = CacheBaseGPU{Y,N,G}(
         rng,
         K,
         x_bin,
@@ -144,7 +157,8 @@ function EvoTrees.init_core(params::EvoTrees.EvoTypes, device::Type{<:EvoTrees.G
         bins_per_feat_gpu,
         split_sums_temp_gpu,
         obliv_gains_gpu,
-        obliv_count_gpu
+        obliv_count_gpu,
+        group_cache
     )
 
     return m, cache

--- a/ext/EvoTreesKernelAbstractionsExt/loss.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/loss.jl
@@ -189,3 +189,21 @@ function EvoTrees.update_grads!(
     KernelAbstractions.synchronize(backend)
     return
 end
+
+# LambdaRank needs each query sorted by score and a pairwise sweep within it. That is a
+# segmented sort plus an irregular inner loop on device, so the arrays are brought to the
+# host and the shared CPU implementation is used.
+function EvoTrees.update_grads!(
+    ∇::CuMatrix,
+    p::CuMatrix,
+    y::CuVector,
+    ::Type{EvoTrees.LambdaRank},
+    params::EvoTrees.EvoTypes,
+    group,
+)
+    isnothing(group) && EvoTrees._lambdarank_no_group()
+    ∇_cpu = Array(∇)
+    EvoTrees._lambdarank_grads!(∇_cpu, Array(p), Array(y), group.index, params.ndcg_k)
+    copyto!(∇, ∇_cpu)
+    return nothing
+end

--- a/ext/EvoTreesKernelAbstractionsExt/metrics.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/metrics.jl
@@ -131,11 +131,9 @@ function EvoTrees.mlogloss(p::CuMatrix{T}, y::CuVector, w::CuVector{T}, eval::Cu
     return sum(eval) / sum(w)
 end
 
-# NDCG needs the documents of each group sorted by predicted score. On device that means a
-# segmented sort over variable-length groups, which is substantially more machinery than
-# every other GPU metric here. NDCG is an eval metric computed once per boosting round on the
-# eval set rather than a hot path, so the predictions are brought to the host and scored
-# there. The result is identical to the CPU path by construction, since it is the same code.
+# NDCG needs each group sorted by predicted score, which on device means a segmented sort
+# over variable-length groups. It is an eval metric run once per round rather than a hot
+# path, so predictions are brought to the host and scored with the CPU code.
 function EvoTrees.ndcg(
     p::CuMatrix{T},
     y::CuVector,

--- a/ext/EvoTreesKernelAbstractionsExt/metrics.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/metrics.jl
@@ -130,3 +130,27 @@ function EvoTrees.mlogloss(p::CuMatrix{T}, y::CuVector, w::CuVector{T}, eval::Cu
     KernelAbstractions.synchronize(backend)
     return sum(eval) / sum(w)
 end
+
+# NDCG needs the documents of each group sorted by predicted score. On device that means a
+# segmented sort over variable-length groups, which is substantially more machinery than
+# every other GPU metric here. NDCG is an eval metric computed once per boosting round on the
+# eval set rather than a hot path, so the predictions are brought to the host and scored
+# there. The result is identical to the CPU path by construction, since it is the same code.
+function EvoTrees.ndcg(
+    p::CuMatrix{T},
+    y::CuVector,
+    w::CuVector{T},
+    eval::CuVector{T};
+    group=nothing,
+    ndcg_k::Int=typemax(Int),
+    kwargs...
+) where {T<:AbstractFloat}
+    isnothing(group) && error(
+        "`metric = :ndcg` requires group information. Pass `group_name` when fitting from a " *
+        "table, or `group_eval` alongside `x_eval` when fitting from a matrix."
+    )
+    p_cpu = Array(p)
+    y_cpu = Array(y)
+    w_cpu = Array(w)
+    return EvoTrees.ndcg(p_cpu, y_cpu, w_cpu, similar(w_cpu, 0); group, ndcg_k)
+end

--- a/ext/EvoTreesKernelAbstractionsExt/metrics.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/metrics.jl
@@ -157,7 +157,7 @@ end
 # arrays are brought to the host rather than scalar-indexed on device.
 function EvoTrees.corr(
     p::CuMatrix{T},
-    y::CuVector,
+    y::Union{CuVector,CuMatrix},
     w::CuVector{T},
     eval::CuVector{T};
     group=nothing,

--- a/ext/EvoTreesKernelAbstractionsExt/metrics.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/metrics.jl
@@ -152,3 +152,23 @@ function EvoTrees.ndcg(
     w_cpu = Array(w)
     return EvoTrees.ndcg(p_cpu, y_cpu, w_cpu, similar(w_cpu, 0); group, ndcg_k)
 end
+
+# Same reasoning as `ndcg` above: a per-group correlation reads its rows individually, so the
+# arrays are brought to the host rather than scalar-indexed on device.
+function EvoTrees.corr(
+    p::CuMatrix{T},
+    y::CuVector,
+    w::CuVector{T},
+    eval::CuVector{T};
+    group=nothing,
+    kwargs...
+) where {T<:AbstractFloat}
+    isnothing(group) && error(
+        "`metric = :corr` requires group information. Pass `group_name` or `eval_group_name` " *
+        "when fitting from a table, or `group_eval` alongside `x_eval` when fitting from a matrix."
+    )
+    p_cpu = Array(p)
+    y_cpu = Array(y)
+    w_cpu = Array(w)
+    return EvoTrees.corr(p_cpu, y_cpu, w_cpu, similar(w_cpu, 0); group)
+end

--- a/ext/EvoTreesKernelAbstractionsExt/structs.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/structs.jl
@@ -1,12 +1,9 @@
 """
 	GroupCacheGPU
 
-Device-side companion to [`EvoTrees.GroupIndex`](@ref) for ranking tasks.
-
-`group_gpu` holds the per-row group id, which is what group-aware sampling gathers through.
-`mask_cpu` / `mask_gpu` are per-group rather than per-row, so one draw covers a whole group.
-`index` is kept on the host because the ranking metric needs a sort within each group, which
-is done host side.
+Device-side companion to [`EvoTrees.GroupIndex`](@ref). `group_gpu` is the per-row group id
+that sampling gathers through, `mask_cpu` / `mask_gpu` are per-group, and `index` stays on
+the host for the metric.
 """
 struct GroupCacheGPU{V,M}
     index::EvoTrees.GroupIndex

--- a/ext/EvoTreesKernelAbstractionsExt/structs.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/structs.jl
@@ -1,4 +1,21 @@
 """
+	GroupCacheGPU
+
+Device-side companion to [`EvoTrees.GroupIndex`](@ref) for ranking tasks.
+
+`group_gpu` holds the per-row group id, which is what group-aware sampling gathers through.
+`mask_cpu` / `mask_gpu` are per-group rather than per-row, so one draw covers a whole group.
+`index` is kept on the host because the ranking metric needs a sort within each group, which
+is done host side.
+"""
+struct GroupCacheGPU{V,M}
+    index::EvoTrees.GroupIndex
+    group_gpu::V
+    mask_cpu::Vector{UInt8}
+    mask_gpu::M
+end
+
+"""
 	CacheBaseGPU <: EvoTrees.CacheGPU
 
 Backend-neutral GPU training cache holding preallocated buffers used during tree growth.
@@ -11,7 +28,7 @@ Backend-neutral GPU training cache holding preallocated buffers used during tree
 - `split_sums_temp_gpu`: per-(node,feature) temporary buffer for K>1 split scanning
 - `obliv_gains_gpu`, `obliv_count_gpu`: oblivious level-gain accumulation
 """
-struct CacheBaseGPU{Y,N<:EvoTrees.TrainNode} <: EvoTrees.CacheGPU
+struct CacheBaseGPU{Y,N<:EvoTrees.TrainNode,G} <: EvoTrees.CacheGPU
     rng::Xoshiro
     K::Int
     x_bin::CuMatrix{UInt8}
@@ -63,6 +80,7 @@ struct CacheBaseGPU{Y,N<:EvoTrees.TrainNode} <: EvoTrees.CacheGPU
     split_sums_temp_gpu::CuMatrix{Float64}   # Temp: per-(node,feature) accumulators [2K+1, n_sampled_feats*max_tree_nodes]
     obliv_gains_gpu::CuMatrix{Float64}       # Oblivious: gain summed over nodes  [nbins, n_sampled_feats]
     obliv_count_gpu::CuMatrix{Int32}         # Oblivious: #nodes with a valid gain [nbins, n_sampled_feats]
+    group::G                                 # `GroupCacheGPU` for ranking, `nothing` otherwise
 
 end
 

--- a/ext/EvoTreesKernelAbstractionsExt/subsample.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/subsample.jl
@@ -7,10 +7,8 @@ function EvoTrees.subsample(is_full::CuVector, mask_cpu::Vector, mask_gpu::CuVec
     return is
 end
 
-# Group-aware subsampling for ranking. One draw per group rather than per row, then a gather
-# through the per-row group id to expand the group mask back to rows. This keeps the same
-# boolean-mask indexing the row sampler uses, with a single gather on top, so a selected
-# group always contributes all of its rows.
+# Group-aware subsampling: one draw per group, then a gather through the per-row group id to
+# expand the mask back to rows. Same boolean-mask indexing as above, with one gather on top.
 function EvoTrees.subsample(is_full::CuVector, mask_cpu::Vector, mask_gpu::CuVector, rowsample::AbstractFloat, rng, g::GroupCacheGPU)
     cond = round(UInt8, 255 * rowsample)
     rand!(rng, g.mask_cpu)

--- a/ext/EvoTreesKernelAbstractionsExt/subsample.jl
+++ b/ext/EvoTreesKernelAbstractionsExt/subsample.jl
@@ -6,3 +6,16 @@ function EvoTrees.subsample(is_full::CuVector, mask_cpu::Vector, mask_gpu::CuVec
     is = is_full[mask_gpu.<=cond]
     return is
 end
+
+# Group-aware subsampling for ranking. One draw per group rather than per row, then a gather
+# through the per-row group id to expand the group mask back to rows. This keeps the same
+# boolean-mask indexing the row sampler uses, with a single gather on top, so a selected
+# group always contributes all of its rows.
+function EvoTrees.subsample(is_full::CuVector, mask_cpu::Vector, mask_gpu::CuVector, rowsample::AbstractFloat, rng, g::GroupCacheGPU)
+    cond = round(UInt8, 255 * rowsample)
+    rand!(rng, g.mask_cpu)
+    copyto!(g.mask_gpu, g.mask_cpu)
+    is = is_full[g.mask_gpu[g.group_gpu].<=cond]
+    length(is) == 0 && error("no subsample group - choose larger rowsample")
+    return is
+end

--- a/src/EvoTrees.jl
+++ b/src/EvoTrees.jl
@@ -28,6 +28,7 @@ import MLJModelInterface: fit, update, predict, schema, feature_importances
 import Base: convert
 import Base: depwarn
 
+include("groups.jl")
 include("learners.jl")
 include("loss.jl")
 include("split.jl")

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -194,6 +194,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:multiquantile`: Loss is an assymetric absolute error, where residuals are penalized as `alpha` or `(1-alpha)` according to their sign.
   - `:gini`: The normalized Gini between pred and target
   - `:ndcg`: Normalized discounted cumulative gain, computed within each group and averaged over groups, with truncation set by `ndcg_k`. Requires groups and evaluation data, so it is only meaningful through `EvoTrees.fit`: the MLJ interface passes neither, and the metric is simply never evaluated there.
+  - `:corr`: Weighted Pearson correlation between prediction and target, computed within each group and averaged over groups. Requires groups and evaluation data, so like `:ndcg` it is only meaningful through `EvoTrees.fit`.
 - `early_stopping_rounds::Integer`: number of consecutive rounds without metric improvement after which fitting in stopped. 
 - `nrounds=100`:           Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
 - `eta=0.1`:               Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -192,6 +192,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:quantile`: Loss is an assymetric absolute error, where residuals are penalized as `alpha` or `(1-alpha)` according to their sign.
   - `:multiquantile`: Loss is an assymetric absolute error, where residuals are penalized as `alpha` or `(1-alpha)` according to their sign.
   - `:gini`: The normalized Gini between pred and target
+  - `:ndcg`: Normalized discounted cumulative gain, computed within each group and averaged over groups. Requires groups to be supplied through `group_name` or `group_eval`. Truncation is set by `ndcg_k`.
 - `early_stopping_rounds::Integer`: number of consecutive rounds without metric improvement after which fitting in stopped. 
 - `nrounds=100`:           Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
 - `eta=0.1`:               Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
@@ -201,11 +202,12 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
 - `gamma=0.0`:            Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `alpha=0.5`:            Loss specific parameter in the [0, 1] range:
                             - `:quantile`: target quantile for the regression.
+- `ndcg_k`:               Truncation rank for `metric = :ndcg`, that is the `k` of NDCG@k. Must be >= 1. Defaults to no truncation, scoring the full list of each group.
 - `max_depth=6`:          Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.
 - `min_weight=1.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
-- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
+- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`. When groups are supplied, whole groups are sampled rather than individual rows, so a group is never split across the sampled and unsampled sets.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `nbins=64`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 
@@ -327,7 +329,7 @@ EvoTreeClassifier is used to perform multi-class classification, using cross-ent
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.
 - `min_weight=1.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
-- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
+- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`. When groups are supplied, whole groups are sampled rather than individual rows, so a group is never split across the sampled and unsampled sets.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `nbins=64`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `tree_type=:binary`     Tree structure to be used. One of:
@@ -586,7 +588,7 @@ EvoTreeGaussian is used to perform Gaussian probabilistic regression, fitting μ
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to 2^max_depth. Typical optimal values are in the 3 to 9 range.
 - `min_weight=8.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
-- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
+- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`. When groups are supplied, whole groups are sampled rather than individual rows, so a group is never split across the sampled and unsampled sets.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `nbins=64`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 
@@ -726,7 +728,7 @@ EvoTreeMLE performs maximum likelihood estimation. Assumed distribution is speci
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to 2^max_depth. Typical optimal values are in the 3 to 9 range.
 - `min_weight=8.0`:       Minimum weight needed in a node to perform a split. Matches the number of observations by default or the sum of weights as provided by the `weights` vector. Must be > 0.
-- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
+- `rowsample=1.0`:        Proportion of rows that are sampled at each iteration to build the tree. Should be in `]0, 1]`. When groups are supplied, whole groups are sampled rather than individual rows, so a group is never split across the sampled and unsampled sets.
 - `colsample=1.0`:        Proportion of columns / features that are sampled at each iteration to build the tree. Should be in `]0, 1]`.
 - `nbins=64`:             Number of bins into which each feature is quantized. Buckets are defined based on quantiles, hence resulting in equal weight bins. Should be between 2 and 255.
 - `monotone_constraints=Dict{Int, Int}()`: Specify monotonic constraints using a dict where the key is the feature index and the value the applicable constraint (-1=decreasing, 0=none, 1=increasing). 

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -181,6 +181,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:multiquantile`
   - `:cred_var`: **experimental** credibility-based gains, derived from ratio of spread to process variance.
   - `:cred_std`: **experimental** credibility-based gains, derived from ratio of spread to process std deviation.
+  - `:lambdarank`: ranking objective. Pairwise within each query, weighted by the NDCG change a swap would cause. Requires groups, and defaults to `metric=:ndcg`.
 - `metric`:     The evaluation metric used to track evaluation data and serves as a basis for early stopping. Supported metrics are: 
   - `:mse`:     Mean-squared error. Adapted for general regression models.
   - `:rmse`:    Root-mean-squared error. Adapted for general regression models.
@@ -202,7 +203,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
 - `gamma=0.0`:            Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `alpha=0.5`:            Loss specific parameter in the [0, 1] range:
                             - `:quantile`: target quantile for the regression.
-- `ndcg_k`:               Truncation rank for `metric = :ndcg`, that is the `k` of NDCG@k. Must be >= 1. Defaults to no truncation, scoring the full list of each group.
+- `ndcg_k`:               Truncation rank for `metric = :ndcg` and for the `:lambdarank` objective, that is the `k` of NDCG@k. Must be >= 1. Defaults to no truncation, scoring the full list of each group.
 - `max_depth=6`:          Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -181,7 +181,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:multiquantile`
   - `:cred_var`: **experimental** credibility-based gains, derived from ratio of spread to process variance.
   - `:cred_std`: **experimental** credibility-based gains, derived from ratio of spread to process std deviation.
-  - `:lambdarank`: ranking objective. Pairwise within each query, weighted by the NDCG change a swap would cause. Requires groups, and defaults to `metric=:ndcg`.
+  - `:lambdarank`: ranking objective. Pairwise within each query, weighted by the NDCG change a swap would cause. Requires groups, so it is only available through `EvoTrees.fit`, not through the MLJ interface, which has no way to pass them.
 - `metric`:     The evaluation metric used to track evaluation data and serves as a basis for early stopping. Supported metrics are: 
   - `:mse`:     Mean-squared error. Adapted for general regression models.
   - `:rmse`:    Root-mean-squared error. Adapted for general regression models.
@@ -193,7 +193,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
   - `:quantile`: Loss is an assymetric absolute error, where residuals are penalized as `alpha` or `(1-alpha)` according to their sign.
   - `:multiquantile`: Loss is an assymetric absolute error, where residuals are penalized as `alpha` or `(1-alpha)` according to their sign.
   - `:gini`: The normalized Gini between pred and target
-  - `:ndcg`: Normalized discounted cumulative gain, computed within each group and averaged over groups. Requires groups to be supplied through `group_name` or `group_eval`. Truncation is set by `ndcg_k`.
+  - `:ndcg`: Normalized discounted cumulative gain, computed within each group and averaged over groups, with truncation set by `ndcg_k`. Requires groups and evaluation data, so it is only meaningful through `EvoTrees.fit`: the MLJ interface passes neither, and the metric is simply never evaluated there.
 - `early_stopping_rounds::Integer`: number of consecutive rounds without metric improvement after which fitting in stopped. 
 - `nrounds=100`:           Number of rounds. It corresponds to the number of trees that will be sequentially stacked. Must be >= 1.
 - `eta=0.1`:               Learning rate. Each tree raw predictions are scaled by `eta` prior to be added to the stack of predictions. Must be > 0.
@@ -203,7 +203,7 @@ A model type for constructing a EvoTreeRegressor, based on [EvoTrees.jl](https:/
 - `gamma=0.0`:            Minimum gain improvement needed to perform a node split. Higher gamma can result in a more robust model. Must be >= 0.
 - `alpha=0.5`:            Loss specific parameter in the [0, 1] range:
                             - `:quantile`: target quantile for the regression.
-- `ndcg_k`:               Truncation rank for `metric = :ndcg` and for the `:lambdarank` objective, that is the `k` of NDCG@k. Must be >= 1. Defaults to no truncation, scoring the full list of each group.
+- `ndcg_k`:               Truncation rank for `metric = :ndcg` and for the `:lambdarank` objective, that is the `k` of NDCG@k. Must be >= 1. Defaults to no truncation, scoring the full list of each group. Ranking is only available through `EvoTrees.fit`, see `:lambdarank` above.
 - `max_depth=6`:          Maximum depth of a tree. Must be >= 1. A tree of depth 1 is made of a single prediction leaf.
   A complete tree of depth N contains `2^(N - 1)` terminal leaves and `2^(N - 1) - 1` split nodes.
   Compute cost is proportional to `2^max_depth`. Typical optimal values are in the 3 to 9 range.

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -67,7 +67,7 @@ function CallBack(
         metric_kwargs = (alphas=alphas_eval,)
     end
     if !isnothing(group_name)
-        group_eval = build_group_index(Tables.getcolumn(deval, Symbol(group_name)))
+        group_eval = build_group_index(Tables.getcolumn(deval, Symbol(group_name)), nobs, "group_name")
         metric_kwargs = merge(metric_kwargs, (group=group_eval,))
     end
     hasproperty(params, :ndcg_k) && (metric_kwargs = merge(metric_kwargs, (ndcg_k=params.ndcg_k,)))
@@ -114,7 +114,7 @@ function CallBack(
         metric_kwargs = (alphas=alphas_eval,)
     end
     if !isnothing(group_eval)
-        metric_kwargs = merge(metric_kwargs, (group=build_group_index(group_eval),))
+        metric_kwargs = merge(metric_kwargs, (group=build_group_index(group_eval, size(x_eval, 1), "group_eval"),))
     end
     hasproperty(params, :ndcg_k) && (metric_kwargs = merge(metric_kwargs, (ndcg_k=params.ndcg_k,)))
 

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -36,7 +36,8 @@ function CallBack(
     device::Type{<:Device};
     target_name,
     weight_name=nothing,
-    offset_name=nothing) where {L,K}
+    offset_name=nothing,
+    group_name=nothing) where {L,K}
 
     T = Float32
     _weight_name = isnothing(weight_name) ? Symbol("") : Symbol(weight_name)
@@ -65,6 +66,11 @@ function CallBack(
         device <: GPU && (alphas_eval = V{T}(alphas_eval))
         metric_kwargs = (alphas=alphas_eval,)
     end
+    if !isnothing(group_name)
+        group_eval = build_group_index(Tables.getcolumn(deval, Symbol(group_name)))
+        metric_kwargs = merge(metric_kwargs, (group=group_eval,))
+    end
+    hasproperty(params, :ndcg_k) && (metric_kwargs = merge(metric_kwargs, (ndcg_k=params.ndcg_k,)))
 
     offset = !isnothing(offset_name) ? T.(Tables.getcolumn(deval, _offset_name)) : nothing
     if !isnothing(offset)
@@ -86,7 +92,8 @@ function CallBack(
     y_eval,
     device::Type{<:Device};
     w_eval=nothing,
-    offset_eval=nothing) where {L,K}
+    offset_eval=nothing,
+    group_eval=nothing) where {L,K}
 
     T = Float32
     x_bin = binarize(x_eval; feature_names=m.info[:feature_names], edges=m.info[:edges])
@@ -106,6 +113,10 @@ function CallBack(
         device <: GPU && (alphas_eval = V{T}(alphas_eval))
         metric_kwargs = (alphas=alphas_eval,)
     end
+    if !isnothing(group_eval)
+        metric_kwargs = merge(metric_kwargs, (group=build_group_index(group_eval),))
+    end
+    hasproperty(params, :ndcg_k) && (metric_kwargs = merge(metric_kwargs, (ndcg_k=params.ndcg_k,)))
 
     offset = !isnothing(offset_eval) ? T.(offset_eval) : nothing
     if !isnothing(offset)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -11,7 +11,9 @@ function grow_evotree!(m::EvoTree{L,K}, cache::CacheCPU, params::EvoTypes) where
     for _ in 1:params.bagging_size
 
         # subsample rows
-        cache.nodes[1].is = subsample(cache.left, cache.is, cache.mask_cond, params.rowsample, cache.rng)
+        cache.nodes[1].is = isnothing(cache.group) ?
+                            subsample(cache.left, cache.is, cache.mask_cond, params.rowsample, cache.rng) :
+                            subsample(cache.left, cache.is, cache.mask_cond, params.rowsample, cache.rng, cache.group)
         # subsample cols
         sample!(cache.rng, UInt32(1):UInt32(length(cache.feattypes)), cache.js, replace=false, ordered=true)
 
@@ -273,6 +275,7 @@ post_fit_gc(::Type{<:CPU}) = nothing
         feature_names=nothing,
         weight_name=nothing,
         offset_name=nothing,
+        group_name=nothing,
         deval=nothing,
         print_every_n=9999,
         verbosity=1
@@ -295,6 +298,7 @@ Main training function. Performs model fitting given configuration `params`, `dt
 - `feature_names = nothing`: the names `dtrain` variables to use as features. If not provided, it deafults to all variables that aren't one of `target`, `weight` or `offset``.
 - `weight_name = nothing`: name of the variable containing weights. If `nothing`, common weights on one will be used.
 - `offset_name = nothing`: name of the offset variable.
+- `group_name = nothing`: name of the variable identifying the group (query) each row belongs to, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows, and is required by `metric = :ndcg`. If `deval` is given it must carry the same column. Currently CPU only.
 - `deval`: A Tables compatible evaluation data containing features and target variables. 
 - `print_every_n`: sets at which frequency logging info should be printed. 
 - `verbosity`: set to 1 to print logging info during training.
@@ -306,6 +310,7 @@ function fit(
     feature_names=nothing,
     weight_name=nothing,
     offset_name=nothing,
+    group_name=nothing,
     deval=nothing,
     print_every_n=9999,
     verbosity=1,
@@ -314,12 +319,12 @@ function fit(
     @assert Tables.istable(dtrain) "fit(params, dtrain) only accepts Tables compatible input for `dtrain` (ex: named tuples, DataFrames...)"
     dtrain = Tables.columntable(dtrain)
     _device = device_type(params.device)
-    m, cache = init(params, dtrain, _device; target_name, feature_names, weight_name, offset_name)
+    m, cache = init(params, dtrain, _device; target_name, feature_names, weight_name, offset_name, group_name)
 
     # initialize callback and logger if deval is provided
     if !isnothing(deval)
         deval = Tables.columntable(deval)
-        cb = CallBack(params, m, deval, _device; target_name, weight_name, offset_name)
+        cb = CallBack(params, m, deval, _device; target_name, weight_name, offset_name, group_name)
         logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds, params.early_stopping_tolerance)
         cb(logger, 0, m.trees[end])
         (verbosity > 0) && @info "initialization" metric = logger[:metrics][end]
@@ -355,6 +360,8 @@ end
         y_eval=nothing, 
         w_eval=nothing, 
         offset_eval=nothing,
+        group_train=nothing,
+        group_eval=nothing,
         feature_names=nothing,
         early_stopping_rounds=9999,
         print_every_n=9999,
@@ -381,6 +388,8 @@ Main training function. Performs model fitting given configuration `params`, `x_
 - `y_eval::VecOrMat`: vector or matrix of evaluation targets of length `#observations` or size `(#targets, #observations)`.
 - `w_eval::Vector`: vector of evaluation weights of length `#observations`. Defaults to `nothing` (assumes a vector of 1s).
 - `offset_eval::VecOrMat`: evaluation data offset. Should match the size of the predictions.
+- `group_train::Vector`: group (query) id of each training row, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows. Currently CPU only.
+- `group_eval::Vector`: group id of each evaluation row. Required by `metric = :ndcg`.
 - `feature_names = nothing`: the names of the `x_train` features. If provided, should be a vector of string with `length(feature_names) = size(x_train, 2)`.
 - `print_every_n`: sets at which frequency logging info should be printed. 
 - `verbosity`: set to 1 to print logging info during training.
@@ -395,13 +404,15 @@ function fit(
     y_eval=nothing,
     w_eval=nothing,
     offset_eval=nothing,
+    group_train=nothing,
+    group_eval=nothing,
     feature_names=nothing,
     print_every_n=9999,
     verbosity=1
 )
 
     _device = device_type(params.device)
-    m, cache = init(params, x_train, y_train, _device; feature_names, w_train, offset_train)
+    m, cache = init(params, x_train, y_train, _device; feature_names, w_train, offset_train, group_train)
 
     # initialize callback and logger if tracking eval data
     metric = params.metric
@@ -411,7 +422,7 @@ function fit(
         @warn "To track eval metric in logger, both `x_eval` and `y_eval` must be provided."
     end
     if logging_flag
-        cb = CallBack(params, m, x_eval, y_eval, _device; w_eval, offset_eval)
+        cb = CallBack(params, m, x_eval, y_eval, _device; w_eval, offset_eval, group_eval)
         logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds, params.early_stopping_tolerance)
         cb(logger, 0, m.trees[end])
         (verbosity > 0) && @info "initialization" metric = logger[:metrics][end]

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -276,6 +276,7 @@ post_fit_gc(::Type{<:CPU}) = nothing
         weight_name=nothing,
         offset_name=nothing,
         group_name=nothing,
+        eval_group_name=group_name,
         deval=nothing,
         print_every_n=9999,
         verbosity=1
@@ -298,7 +299,8 @@ Main training function. Performs model fitting given configuration `params`, `dt
 - `feature_names = nothing`: the names `dtrain` variables to use as features. If not provided, it deafults to all variables that aren't one of `target`, `weight` or `offset``.
 - `weight_name = nothing`: name of the variable containing weights. If `nothing`, common weights on one will be used.
 - `offset_name = nothing`: name of the offset variable.
-- `group_name = nothing`: name of the variable identifying the group (query) each row belongs to, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows, and is required by `metric = :ndcg`. If `deval` is given it must carry the same column.
+- `group_name = nothing`: name of the variable identifying the group (query) each row belongs to. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows.
+- `eval_group_name = group_name`: name of the group variable in `deval`, defaulting to `group_name`. A group-aware metric such as `:ndcg` requires it. Set it on its own to evaluate over groups while training with the usual per-row sampling.
 - `deval`: A Tables compatible evaluation data containing features and target variables. 
 - `print_every_n`: sets at which frequency logging info should be printed. 
 - `verbosity`: set to 1 to print logging info during training.
@@ -311,6 +313,7 @@ function fit(
     weight_name=nothing,
     offset_name=nothing,
     group_name=nothing,
+    eval_group_name=group_name,
     deval=nothing,
     print_every_n=9999,
     verbosity=1,
@@ -324,7 +327,7 @@ function fit(
     # initialize callback and logger if deval is provided
     if !isnothing(deval)
         deval = Tables.columntable(deval)
-        cb = CallBack(params, m, deval, _device; target_name, weight_name, offset_name, group_name)
+        cb = CallBack(params, m, deval, _device; target_name, weight_name, offset_name, group_name=eval_group_name)
         logger = init_logger(; metric=params.metric, maximise=is_maximise(cb.feval), params.early_stopping_rounds, params.early_stopping_tolerance)
         cb(logger, 0, m.trees[end])
         (verbosity > 0) && @info "initialization" metric = logger[:metrics][end]

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -6,7 +6,7 @@ Given a instantiate
 function grow_evotree!(m::EvoTree{L,K}, cache::CacheCPU, params::EvoTypes) where {L,K}
 
     # compute gradients
-    update_grads!(cache.∇, cache.pred, cache.y, L, params)
+    update_grads!(cache.∇, cache.pred, cache.y, L, params, cache.group)
 
     for _ in 1:params.bagging_size
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -298,7 +298,7 @@ Main training function. Performs model fitting given configuration `params`, `dt
 - `feature_names = nothing`: the names `dtrain` variables to use as features. If not provided, it deafults to all variables that aren't one of `target`, `weight` or `offset``.
 - `weight_name = nothing`: name of the variable containing weights. If `nothing`, common weights on one will be used.
 - `offset_name = nothing`: name of the offset variable.
-- `group_name = nothing`: name of the variable identifying the group (query) each row belongs to, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows, and is required by `metric = :ndcg`. If `deval` is given it must carry the same column. Currently CPU only.
+- `group_name = nothing`: name of the variable identifying the group (query) each row belongs to, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows, and is required by `metric = :ndcg`. If `deval` is given it must carry the same column.
 - `deval`: A Tables compatible evaluation data containing features and target variables. 
 - `print_every_n`: sets at which frequency logging info should be printed. 
 - `verbosity`: set to 1 to print logging info during training.
@@ -388,7 +388,7 @@ Main training function. Performs model fitting given configuration `params`, `x_
 - `y_eval::VecOrMat`: vector or matrix of evaluation targets of length `#observations` or size `(#targets, #observations)`.
 - `w_eval::Vector`: vector of evaluation weights of length `#observations`. Defaults to `nothing` (assumes a vector of 1s).
 - `offset_eval::VecOrMat`: evaluation data offset. Should match the size of the predictions.
-- `group_train::Vector`: group (query) id of each training row, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows. Currently CPU only.
+- `group_train::Vector`: group (query) id of each training row, for ranking tasks. Rows sharing an id form one group. Ids need not be contiguous, sorted, or numeric. Supplying groups makes `rowsample` sample whole groups rather than individual rows.
 - `group_eval::Vector`: group id of each evaluation row. Required by `metric = :ndcg`.
 - `feature_names = nothing`: the names of the `x_train` features. If provided, should be a vector of string with `length(feature_names) = size(x_train, 2)`.
 - `print_every_n`: sets at which frequency logging info should be printed. 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -1,0 +1,74 @@
+"""
+    GroupIndex
+
+Row to group mapping for ranking tasks.
+
+A group (a query, in learning-to-rank terms) is a set of rows that are ranked against each
+other. Groups are supplied as a per-row id column rather than as boundary offsets, so the
+rows of a group need not be contiguous in the input. The index built here recovers the rows
+of each group in O(1), which is what both group-aware sampling and per-group metrics need.
+
+- `group` holds the normalised group id of each row, in `1:ngroups`.
+- `rows` holds row indices ordered by group.
+- `ptr` holds the boundaries into `rows`, so group `g` owns `rows[ptr[g]:ptr[g+1]-1]`.
+"""
+struct GroupIndex
+    group::Vector{UInt32}
+    rows::Vector{UInt32}
+    ptr::Vector{UInt32}
+end
+
+"""
+    ngroups(gi::GroupIndex)
+
+Number of distinct groups.
+"""
+ngroups(gi::GroupIndex) = length(gi.ptr) - 1
+
+"""
+    group_rows(gi::GroupIndex, g)
+
+Row indices belonging to group `g`, as a view.
+"""
+@inline group_rows(gi::GroupIndex, g) = view(gi.rows, gi.ptr[g]:(gi.ptr[g+1]-one(UInt32)))
+
+Base.length(gi::GroupIndex) = length(gi.group)
+
+"""
+    build_group_index(raw::AbstractVector)
+
+Build a [`GroupIndex`](@ref) from a per-row group id column. Ids may be of any type
+supporting `sort` and `isequal`, and need not be contiguous, sorted, or numeric.
+"""
+function build_group_index(raw::AbstractVector)
+    n = length(raw)
+    n == 0 && error("`group` must be non-empty.")
+    levels = sort(unique(raw))
+    lookup = Dict(lv => UInt32(i) for (i, lv) in enumerate(levels))
+    group = Vector{UInt32}(undef, n)
+    @inbounds for i in 1:n
+        group[i] = lookup[raw[i]]
+    end
+    return _index_from_ids(group, UInt32(length(levels)))
+end
+
+# Counting sort of row indices by group id, giving `rows` and `ptr`.
+function _index_from_ids(group::Vector{UInt32}, ng::UInt32)
+    counts = zeros(UInt32, ng)
+    @inbounds for g in group
+        counts[g] += one(UInt32)
+    end
+    ptr = Vector{UInt32}(undef, ng + 1)
+    ptr[1] = one(UInt32)
+    @inbounds for g in 1:ng
+        ptr[g+1] = ptr[g] + counts[g]
+    end
+    cursor = copy(ptr)
+    rows = Vector{UInt32}(undef, length(group))
+    @inbounds for i in eachindex(group)
+        g = group[i]
+        rows[cursor[g]] = UInt32(i)
+        cursor[g] += one(UInt32)
+    end
+    return GroupIndex(group, rows, ptr)
+end

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -35,14 +35,24 @@ Row indices belonging to group `g`, as a view.
 Base.length(gi::GroupIndex) = length(gi.group)
 
 """
-    build_group_index(raw::AbstractVector)
+    build_group_index(raw::AbstractVector, nobs=nothing, argname="group")
 
 Build a [`GroupIndex`](@ref) from a per-row group id column. Ids may be of any type
 supporting `sort` and `isequal`, and need not be contiguous, sorted, or numeric.
+
+`nobs` is the number of observations the ids must cover. It is checked, because a group
+column of the wrong length would otherwise be accepted: a short one silently scores or
+trains on a subset, and a long one indexes past the end of the predictions.
 """
-function build_group_index(raw::AbstractVector)
+function build_group_index(raw::AbstractVector, nobs::Union{Nothing,Integer}=nothing, argname::AbstractString="group")
     n = length(raw)
-    n == 0 && error("`group` must be non-empty.")
+    n == 0 && error("`$(argname)` must be non-empty.")
+    if !isnothing(nobs) && n != nobs
+        error(
+            "`$(argname)` has length $(n) but there are $(nobs) observations. " *
+            "Each row needs exactly one group id."
+        )
+    end
     levels = sort(unique(raw))
     lookup = Dict(lv => UInt32(i) for (i, lv) in enumerate(levels))
     group = Vector{UInt32}(undef, n)

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -1,16 +1,11 @@
 """
     GroupIndex
 
-Row to group mapping for ranking tasks.
+Row to group (query) mapping for ranking. Groups are given as a per-row id column rather
+than boundary offsets, so a group's rows need not be contiguous.
 
-A group (a query, in learning-to-rank terms) is a set of rows that are ranked against each
-other. Groups are supplied as a per-row id column rather than as boundary offsets, so the
-rows of a group need not be contiguous in the input. The index built here recovers the rows
-of each group in O(1), which is what both group-aware sampling and per-group metrics need.
-
-- `group` holds the normalised group id of each row, in `1:ngroups`.
-- `rows` holds row indices ordered by group.
-- `ptr` holds the boundaries into `rows`, so group `g` owns `rows[ptr[g]:ptr[g+1]-1]`.
+`group` is the normalised id of each row in `1:ngroups`, `rows` holds row indices ordered by
+group, and `ptr` bounds them, so group `g` owns `rows[ptr[g]:ptr[g+1]-1]`.
 """
 struct GroupIndex
     group::Vector{UInt32}
@@ -18,18 +13,8 @@ struct GroupIndex
     ptr::Vector{UInt32}
 end
 
-"""
-    ngroups(gi::GroupIndex)
-
-Number of distinct groups.
-"""
 ngroups(gi::GroupIndex) = length(gi.ptr) - 1
 
-"""
-    group_rows(gi::GroupIndex, g)
-
-Row indices belonging to group `g`, as a view.
-"""
 @inline group_rows(gi::GroupIndex, g) = view(gi.rows, gi.ptr[g]:(gi.ptr[g+1]-one(UInt32)))
 
 Base.length(gi::GroupIndex) = length(gi.group)
@@ -40,9 +25,8 @@ Base.length(gi::GroupIndex) = length(gi.group)
 Build a [`GroupIndex`](@ref) from a per-row group id column. Ids may be of any type
 supporting `sort` and `isequal`, and need not be contiguous, sorted, or numeric.
 
-`nobs` is the number of observations the ids must cover. It is checked, because a group
-column of the wrong length would otherwise be accepted: a short one silently scores or
-trains on a subset, and a long one indexes past the end of the predictions.
+`nobs` is checked when given: a short group column would otherwise silently train or score
+on a subset, and a long one would index past the end of the predictions.
 """
 function build_group_index(raw::AbstractVector, nobs::Union{Nothing,Integer}=nothing, argname::AbstractString="group")
     n = length(raw)
@@ -62,7 +46,6 @@ function build_group_index(raw::AbstractVector, nobs::Union{Nothing,Integer}=not
     return _index_from_ids(group, UInt32(length(levels)))
 end
 
-# Counting sort of row indices by group id, giving `rows` and `ptr`.
 function _index_from_ids(group::Vector{UInt32}, ng::UInt32)
     counts = zeros(UInt32, ng)
     @inbounds for g in group

--- a/src/init.jl
+++ b/src/init.jl
@@ -132,7 +132,13 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
         end
     else
         @assert eltype(y_train) <: Real
-        if L <: GradientRegression
+        if L == LambdaRank
+            # Scores are relative within a query, so a constant bias cancels.
+            @assert minimum(y_train) >= 0 "`:lambdarank` requires non-negative graded relevance."
+            K = 1
+            y = T.(y_train)
+            μ = T[0]
+        elseif L <: GradientRegression
             if y_train isa AbstractVector
                 K = 1
                 y = T.(y_train)

--- a/src/init.jl
+++ b/src/init.jl
@@ -243,18 +243,6 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     return m, cache
 end
 
-# Group-aware training is CPU only for now. Fail with a message that says so rather than
-# letting the GPU `init_core` reject the extra argument with a MethodError.
-function _assert_group_device(has_group::Bool, device)
-    if has_group && !(device <: CPU)
-        error(
-            "Group-aware training is currently supported on CPU only. " *
-            "Set `device = :cpu`, or drop `group_name` / `group_train`."
-        )
-    end
-    return nothing
-end
-
 """
     init(
         params::EvoTypes,
@@ -278,8 +266,6 @@ function init(
     offset_name=nothing,
     group_name=nothing
 )
-
-    _assert_group_device(!isnothing(group_name), device)
 
     # set feature_names
     schema = Tables.schema(dtrain)
@@ -350,8 +336,6 @@ function init(
     offset_train=nothing,
     group_train=nothing
 )
-
-    _assert_group_device(!isnothing(group_train), device)
 
     # initialize model and cache
     feature_names = isnothing(feature_names) ? [Symbol("feat_$i") for i in axes(x_train, 2)] : Symbol.(feature_names)

--- a/src/init.jl
+++ b/src/init.jl
@@ -152,7 +152,7 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
     return K, y, μ, target_levels, target_isordered
 end
 
-function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, w, offset)
+function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, w, offset, group=nothing)
 
     # binarize data into quantiles
     rng = Xoshiro(params.seed)
@@ -217,7 +217,8 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
     Y = typeof(y)
     N = typeof(first(nodes))
     H = typeof(h∇)
-    cache = CacheBaseCPU{Y,N,H}(
+    G = typeof(group)
+    cache = CacheBaseCPU{Y,N,H,G}(
         rng,
         K,
         x_bin,
@@ -237,8 +238,21 @@ function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, 
         featbins,
         feattypes,
         monotone_constraints,
+        group,
     )
     return m, cache
+end
+
+# Group-aware training is CPU only for now. Fail with a message that says so rather than
+# letting the GPU `init_core` reject the extra argument with a MethodError.
+function _assert_group_device(has_group::Bool, device)
+    if has_group && !(device <: CPU)
+        error(
+            "Group-aware training is currently supported on CPU only. " *
+            "Set `device = :cpu`, or drop `group_name` / `group_train`."
+        )
+    end
+    return nothing
 end
 
 """
@@ -261,13 +275,17 @@ function init(
     target_name,
     feature_names=nothing,
     weight_name=nothing,
-    offset_name=nothing
+    offset_name=nothing,
+    group_name=nothing
 )
+
+    _assert_group_device(!isnothing(group_name), device)
 
     # set feature_names
     schema = Tables.schema(dtrain)
     _weight_name = isnothing(weight_name) ? Symbol("") : Symbol(weight_name)
     _offset_name = isnothing(offset_name) ? Symbol("") : Symbol(offset_name)
+    _group_name = isnothing(group_name) ? Symbol("") : Symbol(group_name)
     _target_names = target_name isa AbstractVector ? Symbol.(target_name) : [Symbol(target_name)]
     if isnothing(feature_names)
         feature_names = Symbol[]
@@ -276,7 +294,7 @@ function init(
                 push!(feature_names, schema.names[i])
             end
         end
-        feature_names = setdiff(feature_names, union(_target_names, [_weight_name], [_offset_name]))
+        feature_names = setdiff(feature_names, union(_target_names, [_weight_name], [_offset_name], [_group_name]))
     else
         isa(feature_names, String) ? feature_names = [feature_names] : nothing
         feature_names = Symbol.(feature_names)
@@ -295,10 +313,12 @@ function init(
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(dtrain, _weight_name))
     offset = isnothing(offset_name) ? nothing : V{T}(Tables.getcolumn(dtrain, _offset_name))
+    group = isnothing(group_name) ? nothing : build_group_index(Tables.getcolumn(dtrain, _group_name))
 
-    m, cache = init_core(params, device, dtrain, feature_names, y_train, w, offset)
+    m, cache = init_core(params, device, dtrain, feature_names, y_train, w, offset, group)
 
     m.info[:target_names] = _target_names
+    m.info[:group_name] = isnothing(group_name) ? nothing : _group_name
 
     return m, cache
 end
@@ -327,8 +347,11 @@ function init(
     device::Type{<:Device}=CPU;
     feature_names=nothing,
     w_train=nothing,
-    offset_train=nothing
+    offset_train=nothing,
+    group_train=nothing
 )
+
+    _assert_group_device(!isnothing(group_train), device)
 
     # initialize model and cache
     feature_names = isnothing(feature_names) ? [Symbol("feat_$i") for i in axes(x_train, 2)] : Symbol.(feature_names)
@@ -339,8 +362,9 @@ function init(
     V = device_array_type(device)
     w = isnothing(w_train) ? device_ones(device, T, nobs) : V{T}(w_train)
     offset = isnothing(offset_train) ? nothing : V{T}(offset_train)
+    group = isnothing(group_train) ? nothing : build_group_index(group_train)
 
-    m, cache = init_core(params, device, x_train, feature_names, y_train, w, offset)
+    m, cache = init_core(params, device, x_train, feature_names, y_train, w, offset, group)
 
     return m, cache
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -299,7 +299,7 @@ function init(
     V = device_array_type(device)
     w = isnothing(weight_name) ? device_ones(device, T, nobs) : V{T}(Tables.getcolumn(dtrain, _weight_name))
     offset = isnothing(offset_name) ? nothing : V{T}(Tables.getcolumn(dtrain, _offset_name))
-    group = isnothing(group_name) ? nothing : build_group_index(Tables.getcolumn(dtrain, _group_name))
+    group = isnothing(group_name) ? nothing : build_group_index(Tables.getcolumn(dtrain, _group_name), nobs, "group_name")
 
     m, cache = init_core(params, device, dtrain, feature_names, y_train, w, offset, group)
 
@@ -346,7 +346,7 @@ function init(
     V = device_array_type(device)
     w = isnothing(w_train) ? device_ones(device, T, nobs) : V{T}(w_train)
     offset = isnothing(offset_train) ? nothing : V{T}(offset_train)
-    group = isnothing(group_train) ? nothing : build_group_index(group_train)
+    group = isnothing(group_train) ? nothing : build_group_index(group_train, nobs, "group_train")
 
     m, cache = init_core(params, device, x_train, feature_names, y_train, w, offset, group)
 

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -16,6 +16,7 @@ mutable struct EvoTreeRegressor <: MMI.Deterministic
     nbins::Int
     alpha::Float64
     alphas::Vector{Float64}
+    ndcg_k::Int
     monotone_constraints::Dict{Int,Int}
     tree_type::Symbol
     seed::Int
@@ -43,6 +44,7 @@ function EvoTreeRegressor(; kwargs...)
         :nbins => 64,
         :alpha => 0.5,
         :alphas => [0.1, 0.5, 0.9],
+        :ndcg_k => typemax(Int),
         :monotone_constraints => Dict{Int,Int}(),
         :tree_type => :binary,
         :seed => 123,
@@ -72,7 +74,7 @@ function EvoTreeRegressor(; kwargs...)
         error("Invalid loss. Must be one of: $_loss_list")
     end
 
-    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :multiquantile, :gini]
+    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :multiquantile, :gini, :ndcg]
     if isnothing(args[:metric])
         if loss ∈ [:cred_std, :cred_var]
             metric = :mae
@@ -109,6 +111,7 @@ function EvoTreeRegressor(; kwargs...)
         args[:nbins],
         args[:alpha],
         alphas,
+        args[:ndcg_k],
         args[:monotone_constraints],
         tree_type,
         args[:seed],
@@ -527,6 +530,7 @@ function check_args(args::Dict{Symbol,Any})
     check_parameter(Int, args[:nbins], 2, 255, :nbins)
     check_parameter(Int, args[:bagging_size], 1, typemax(Int), :bagging_size)
     check_parameter(Int, args[:early_stopping_rounds], 0, typemax(Int), :early_stopping_rounds)
+    haskey(args, :ndcg_k) && check_parameter(Int, args[:ndcg_k], 1, typemax(Int), :ndcg_k)
 
     # check positive float parameters
     check_parameter(Float64, args[:L2], zero(Float64), typemax(Float64), :L2)
@@ -568,6 +572,7 @@ function check_args(model::EvoTypes)
     check_parameter(Int, model.nbins, 2, 255, :nbins)
     check_parameter(Int, model.bagging_size, 1, typemax(Int), :bagging_size)
     check_parameter(Int, model.early_stopping_rounds, 0, typemax(Int), :early_stopping_rounds)
+    hasproperty(model, :ndcg_k) && check_parameter(Int, model.ndcg_k, 1, typemax(Int), :ndcg_k)
 
     # check positive float parameters
     check_parameter(Float64, model.L2, zero(Float64), typemax(Float64), :L2)

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -60,7 +60,7 @@ function EvoTreeRegressor(; kwargs...)
         args[arg] = kwargs[arg]
     end
 
-    _loss_list = [:mse, :logloss, :poisson, :gamma, :tweedie, :mae, :quantile, :multiquantile, :cred_std, :cred_var]
+    _loss_list = [:mse, :logloss, :poisson, :gamma, :tweedie, :mae, :quantile, :multiquantile, :cred_std, :cred_var, :lambdarank]
     loss = Symbol(args[:loss])
     if loss == :linear
         loss = :mse
@@ -78,6 +78,8 @@ function EvoTreeRegressor(; kwargs...)
     if isnothing(args[:metric])
         if loss ∈ [:cred_std, :cred_var]
             metric = :mae
+        elseif loss == :lambdarank
+            metric = :ndcg
         else
             metric = loss
         end

--- a/src/learners.jl
+++ b/src/learners.jl
@@ -74,7 +74,7 @@ function EvoTreeRegressor(; kwargs...)
         error("Invalid loss. Must be one of: $_loss_list")
     end
 
-    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :multiquantile, :gini, :ndcg]
+    _metric_list = [:mse, :rmse, :mae, :logloss, :poisson, :gamma, :tweedie, :quantile, :multiquantile, :gini, :ndcg, :corr]
     if isnothing(args[:metric])
         if loss ∈ [:cred_std, :cred_var]
             metric = :mae
@@ -354,7 +354,7 @@ function EvoTreeMLE(; kwargs...)
         error("Invalid loss. Must be one of: $_loss_list")
     end
 
-    _metric_list = [:gaussian_mle, :logistic_mle]
+    _metric_list = [:gaussian_mle, :logistic_mle, :corr]
     if isnothing(args[:metric])
         if loss ∈ [:cred_std, :cred_var]
             metric = :mae

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -107,6 +107,7 @@ update_grads!(∇, p, y, ::Type{L}, params::EvoTypes, group) where {L} =
 # LambdaRank, per Burges' "From RankNet to LambdaRank to LambdaMART". Pairs within a query
 # contribute a pairwise logistic cost weighted by the NDCG change a swap would cause. The
 # lambdas stay per-document, so K = 1 and the histogram and leaf solver are untouched.
+# Cost is quadratic in the size of a query, so very large groups are the pathological case.
 function _lambdarank_group!(∇::Matrix{T}, p::Matrix{T}, y, rows, ndcg_k::Int) where {T}
     n = length(rows)
     n < 2 && return nothing

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -108,14 +108,46 @@ update_grads!(∇, p, y, ::Type{L}, params::EvoTypes, group) where {L} =
 # contribute a pairwise logistic cost weighted by the NDCG change a swap would cause. The
 # lambdas stay per-document, so K = 1 and the histogram and leaf solver are untouched.
 # Cost is quadratic in the size of a query, so very large groups are the pathological case.
-function _lambdarank_group!(∇::Matrix{T}, p::Matrix{T}, y, rows, ndcg_k::Int) where {T}
+# Per-group temporaries, reused across the groups a thread handles. Allocating them per
+# group left the gradient churning gigabytes over a fit.
+struct LambdaRankScratch
+    scores::Vector{Float64}
+    rel::Vector{Float64}
+    ideal::Vector{Float64}
+    disc::Vector{Float64}
+    ord::Vector{Int}
+    rank::Vector{Int}
+end
+LambdaRankScratch() = LambdaRankScratch(Float64[], Float64[], Float64[], Float64[], Int[], Int[])
+
+# The chunk body is its own function so the `@threads` closure does not box its captures,
+# which would otherwise make every per-group call a dynamic dispatch.
+function _lambdarank_chunk!(∇::Matrix{T}, p::Matrix{T}, y, group, chunk, ndcg_k::Int) where {T}
+    buf = LambdaRankScratch()
+    for g in chunk
+        _lambdarank_group!(buf, ∇, p, y, group_rows(group, g), ndcg_k)
+    end
+    return nothing
+end
+
+function _lambdarank_group!(buf::LambdaRankScratch, ∇::Matrix{T}, p::Matrix{T}, y, rows, ndcg_k::Int) where {T}
     n = length(rows)
     n < 2 && return nothing
 
-    scores = [Float64(p[1, r]) for r in rows]
-    rel = [Float64(y[r]) for r in rows]
+    scores, rel, ideal = buf.scores, buf.rel, buf.ideal
+    ord, rank, disc = buf.ord, buf.rank, buf.disc
+    for v in (scores, rel, ideal, disc)
+        resize!(v, n)
+    end
+    resize!(ord, n)
+    resize!(rank, n)
+    @inbounds for (i, r) in enumerate(rows)
+        scores[i] = p[1, r]
+        rel[i] = y[r]
+    end
 
-    ideal = sort(rel; rev=true)
+    copyto!(ideal, rel)
+    sort!(ideal; rev=true, alg=QuickSort)
     kk = min(ndcg_k, n)
     maxdcg = 0.0
     @inbounds for i in 1:kk
@@ -123,13 +155,11 @@ function _lambdarank_group!(∇::Matrix{T}, p::Matrix{T}, y, rows, ndcg_k::Int) 
     end
     maxdcg <= 0 && return nothing   # no relevant document, so no ranking signal
 
-    ord = sortperm(scores; rev=true)
-    rank = Vector{Int}(undef, n)
+    sortperm!(ord, scores; rev=true, alg=QuickSort)
     @inbounds for pos in 1:n
         rank[ord[pos]] = pos
     end
     # Positions past k get no discount, so a pair wholly below the cutoff yields a zero delta.
-    disc = Vector{Float64}(undef, n)
     @inbounds for pos in 1:n
         disc[pos] = pos <= ndcg_k ? 1 / log2(pos + 1) : 0.0
     end
@@ -158,8 +188,9 @@ end
 function _lambdarank_grads!(∇::Matrix{T}, p::Matrix{T}, y, group, ndcg_k::Int) where {T}
     fill!(view(∇, 1, :), zero(T))
     fill!(view(∇, 2, :), zero(T))
-    @threads for g in 1:ngroups(group)
-        _lambdarank_group!(∇, p, y, group_rows(group, g), ndcg_k)
+    ng = ngroups(group)
+    @threads for chunk in _group_chunks(ng)
+        _lambdarank_chunk!(∇, p, y, group, chunk, ndcg_k)
     end
     @inbounds @threads for i in axes(∇, 2)
         w = ∇[3, i]

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -97,6 +97,19 @@ end
     return (is_target ? prob - one(prob) : prob, prob * (1 - prob))
 end
 
+"""
+    update_grads!(∇, p, y, ::Type{L}, params, group)
+
+Gradient update with the group (query) index made available to the loss.
+
+Every loss currently defined is computed per observation and ignores `group`, so this
+forwards to the group-free method. A group-defined objective such as LambdaRank, whose
+gradients depend on the other documents in the same query, defines its own method on this
+signature and is dispatched to without any change at the call site.
+"""
+update_grads!(∇, p, y, ::Type{L}, params::EvoTypes, group) where {L} =
+    update_grads!(∇, p, y, L, params)
+
 function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{L}, params::EvoTypes) where {T,L<:GradientRegression}
     K = size(p, 1)
     w_row = 2 * K + 1

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -3,6 +3,7 @@ abstract type GradientRegression <: LossType end
 abstract type MLE2P <: LossType end # 2-parameters max-likelihood
 
 abstract type MSE <: GradientRegression end
+abstract type LambdaRank <: GradientRegression end
 abstract type LogLoss <: GradientRegression end
 abstract type Poisson <: GradientRegression end
 abstract type Gamma <: GradientRegression end
@@ -19,6 +20,7 @@ abstract type CredStd <: Cred end
 
 const _loss2type_dict = Dict(
     :mse => MSE,
+    :lambdarank => LambdaRank,
     :logloss => LogLoss,
     :poisson => Poisson,
     :gamma => Gamma,
@@ -97,18 +99,84 @@ end
     return (is_target ? prob - one(prob) : prob, prob * (1 - prob))
 end
 
-"""
-    update_grads!(∇, p, y, ::Type{L}, params, group)
-
-Gradient update with the group (query) index made available to the loss.
-
-Every loss currently defined is computed per observation and ignores `group`, so this
-forwards to the group-free method. A group-defined objective such as LambdaRank, whose
-gradients depend on the other documents in the same query, defines its own method on this
-signature and is dispatched to without any change at the call site.
-"""
+# Losses computed per observation ignore `group` and forward to the group-free method.
+# A group-defined objective defines its own method on this signature instead.
 update_grads!(∇, p, y, ::Type{L}, params::EvoTypes, group) where {L} =
     update_grads!(∇, p, y, L, params)
+
+# LambdaRank, per Burges' "From RankNet to LambdaRank to LambdaMART". Pairs within a query
+# contribute a pairwise logistic cost weighted by the NDCG change a swap would cause. The
+# lambdas stay per-document, so K = 1 and the histogram and leaf solver are untouched.
+function _lambdarank_group!(∇::Matrix{T}, p::Matrix{T}, y, rows, ndcg_k::Int) where {T}
+    n = length(rows)
+    n < 2 && return nothing
+
+    scores = [Float64(p[1, r]) for r in rows]
+    rel = [Float64(y[r]) for r in rows]
+
+    ideal = sort(rel; rev=true)
+    kk = min(ndcg_k, n)
+    maxdcg = 0.0
+    @inbounds for i in 1:kk
+        maxdcg += (2.0^ideal[i] - 1) / log2(i + 1)
+    end
+    maxdcg <= 0 && return nothing   # no relevant document, so no ranking signal
+
+    ord = sortperm(scores; rev=true)
+    rank = Vector{Int}(undef, n)
+    @inbounds for pos in 1:n
+        rank[ord[pos]] = pos
+    end
+    # Positions past k get no discount, so a pair wholly below the cutoff yields a zero delta.
+    disc = Vector{Float64}(undef, n)
+    @inbounds for pos in 1:n
+        disc[pos] = pos <= ndcg_k ? 1 / log2(pos + 1) : 0.0
+    end
+
+    @inbounds for a in 1:n
+        ga = 2.0^rel[a] - 1
+        for b in 1:n
+            rel[a] > rel[b] || continue
+            gb = 2.0^rel[b] - 1
+            delta = abs((ga - gb) * (disc[rank[a]] - disc[rank[b]])) / maxdcg
+            delta == 0 && continue
+            ρ = 1 / (1 + exp(scores[a] - scores[b]))
+            λ = -ρ * delta
+            h = ρ * (1 - ρ) * delta
+            ra, rb = rows[a], rows[b]
+            ∇[1, ra] += T(λ)
+            ∇[1, rb] -= T(λ)
+            ∇[2, ra] += T(h)
+            ∇[2, rb] += T(h)
+        end
+    end
+    return nothing
+end
+
+# Shared by both backends: the GPU path brings its arrays to the host and calls this.
+function _lambdarank_grads!(∇::Matrix{T}, p::Matrix{T}, y, group, ndcg_k::Int) where {T}
+    fill!(view(∇, 1, :), zero(T))
+    fill!(view(∇, 2, :), zero(T))
+    @threads for g in 1:ngroups(group)
+        _lambdarank_group!(∇, p, y, group_rows(group, g), ndcg_k)
+    end
+    @inbounds @threads for i in axes(∇, 2)
+        w = ∇[3, i]
+        ∇[1, i] *= w
+        ∇[2, i] *= w
+    end
+    return nothing
+end
+
+_lambdarank_no_group() = error(
+    "`loss = :lambdarank` requires group information. Pass `group_name` when fitting " *
+    "from a table, or `group_train` when fitting from a matrix."
+)
+
+function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{LambdaRank}, params::EvoTypes, group) where {T}
+    isnothing(group) && _lambdarank_no_group()
+    _lambdarank_grads!(∇, p, y, group, params.ndcg_k)
+end
 
 function update_grads!(∇::Matrix{T}, p::Matrix{T}, y::AbstractVecOrMat, ::Type{L}, params::EvoTypes) where {T,L<:GradientRegression}
     K = size(p, 1)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -165,8 +165,8 @@ end
 
 Normalised discounted cumulative gain, computed within each group then averaged over groups.
 Requires the group index supplied at fit through `group_name` or `group_eval`. A group's weight
-is the sum of its rows' weights, so per-observation weights aggregate to a query weight and the
-default of unit weights makes a group count in proportion to its size.
+is the mean of its rows' weights, so the default of unit weights leaves every group equally
+weighted while relative weights within a group still carry through.
 """
 function ndcg(
     p::AbstractMatrix{T},
@@ -189,7 +189,7 @@ function ndcg(
         pred = [p[1, r] for r in rows]
         rel = [y[r] for r in rows]
         scores[g] = _ndcg_group(pred, rel, ndcg_k)
-        weights[g] = sum(w[r] for r in rows)
+        weights[g] = mean(w[r] for r in rows)
     end
     return sum(scores .* weights) / sum(weights)
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -143,15 +143,78 @@ end
 
 
 # NDCG within a single group, `pred` and `rel` in matching order.
-function _ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int)
+# The chunk bodies live in their own functions so the `@threads` closure does not box the
+# captured arrays, which otherwise makes every per-group call a dynamic dispatch.
+function _ndcg_chunk!(scores, weights, p, y, w, group, chunk, ndcg_k::Int)
+    pred = Float64[]
+    rel = Float64[]
+    ord = Int[]
+    ideal = Float64[]
+    for g in chunk
+        rows = group_rows(group, g)
+        n = length(rows)
+        resize!(pred, n)
+        resize!(rel, n)
+        sw = 0.0
+        @inbounds for (i, r) in enumerate(rows)
+            pred[i] = p[1, r]
+            rel[i] = y[r]
+            sw += w[r]
+        end
+        scores[g] = _ndcg_group!(ord, ideal, pred, rel, ndcg_k)
+        weights[g] = sw / n
+    end
+    return nothing
+end
+
+function _corr_chunk!(scores, weights, p, y, w, group, chunk, K::Int)
+    pred = Float64[]
+    obs = Float64[]
+    wt = Float64[]
+    for g in chunk
+        rows = group_rows(group, g)
+        # each target correlates on its own, then the group takes their mean, matching
+        # how the per-observation metrics average over K
+        acc = 0.0
+        scored = 0
+        for k in 1:K
+            s = _corr_group!(pred, obs, wt, p, y, w, rows, k)
+            isnothing(s) && continue
+            acc += s
+            scored += 1
+        end
+        scored == 0 && continue
+        scores[g] = acc / scored
+        sw = 0.0
+        @inbounds for r in rows
+            sw += w[r]
+        end
+        weights[g] = sw / length(rows)
+    end
+    return nothing
+end
+
+# One chunk per thread, so per-group scratch can be allocated once per chunk rather than
+# once per group. Chunks rather than `threadid()` because tasks may migrate between threads.
+function _group_chunks(ng::Int)
+    nt = min(Threads.nthreads(), max(ng, 1))
+    per = cld(ng, nt)
+    return [((c - 1) * per + 1):min(c * per, ng) for c in 1:nt if (c - 1) * per + 1 <= ng]
+end
+
+function _ndcg_group!(ord::Vector{Int}, ideal::Vector{Float64}, pred::AbstractVector, rel::AbstractVector, k::Int)
     n = length(rel)
     kk = min(k, n)
-    ord = sortperm(pred; rev=true)
+    resize!(ord, n)
+    # QuickSort is in place; the default hybrid allocates scratch on every call
+    sortperm!(ord, pred; rev=true, alg=QuickSort)
     dcg = 0.0
     @inbounds for i in 1:kk
         dcg += (2.0^rel[ord[i]] - 1) / log2(i + 1)
     end
-    ideal = sort(rel; rev=true)
+    resize!(ideal, n)
+    copyto!(ideal, rel)
+    sort!(ideal; rev=true, alg=QuickSort)
     idcg = 0.0
     @inbounds for i in 1:kk
         idcg += (2.0^ideal[i] - 1) / log2(i + 1)
@@ -159,6 +222,9 @@ function _ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int)
     # All-irrelevant groups score 1.0, matching the convention in the LTRC tutorial.
     return idcg > 0 ? dcg / idcg : 1.0
 end
+
+_ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int) =
+    _ndcg_group!(Vector{Int}(undef, length(rel)), Vector{Float64}(undef, length(rel)), pred, rel, k)
 
 """
     ndcg(p, y, w, eval; group, ndcg_k, kwargs...)
@@ -186,30 +252,64 @@ function ndcg(
     ng = ngroups(group)
     scores = zeros(Float64, ng)
     weights = zeros(Float64, ng)
-    @threads for g in 1:ng
-        rows = group_rows(group, g)
-        pred = [p[1, r] for r in rows]
-        rel = [y[r] for r in rows]
-        scores[g] = _ndcg_group(pred, rel, ndcg_k)
-        weights[g] = mean(w[r] for r in rows)
+    # Groups are row ids rather than boundaries, so a group's rows need not be contiguous and
+    # cannot be viewed. Scratch buffers are per chunk instead, so the gather does not allocate
+    # once per group.
+    @threads for chunk in _group_chunks(ng)
+        _ndcg_chunk!(scores, weights, p, y, w, group, chunk, ndcg_k)
     end
     return sum(scores .* weights) / sum(weights)
 end
 
-function _corr_group(pred::AbstractVector, obs::AbstractVector, wt::AbstractVector)
-    length(pred) < 2 && return nothing
-    sw = sum(wt)
+# The rows of a group are scattered, so they are gathered once into contiguous scratch and
+# the two moment passes then run over that rather than chasing the same scattered reads
+# twice. The accumulator is Float64 regardless of `T`, because the centring cancels
+# catastrophically in Float32 once predictions sit far from zero.
+function _corr_group!(pred::Vector{Float64}, obs::Vector{Float64}, wt::Vector{Float64},
+    p::AbstractMatrix, y, w::AbstractVector, rows, k::Int)
+    n = length(rows)
+    n < 2 && return nothing
+    resize!(pred, n)
+    resize!(obs, n)
+    resize!(wt, n)
+    # the gather is scattered and cannot vectorise, so it is kept apart from the arithmetic,
+    # which then runs over contiguous scratch
+    @inbounds for (i, r) in enumerate(rows)
+        pred[i] = p[k, r]
+        obs[i] = _target(y, k, r)
+        wt[i] = w[r]
+    end
+    sw = 0.0
+    mp = 0.0
+    mo = 0.0
+    @inbounds @simd for i in 1:n
+        sw += wt[i]
+        mp += wt[i] * pred[i]
+        mo += wt[i] * obs[i]
+    end
     sw <= 0 && return nothing
-    mp = sum(wt .* pred) / sw
-    mo = sum(wt .* obs) / sw
-    vp = sum(wt .* (pred .- mp) .^ 2) / sw
-    vo = sum(wt .* (obs .- mo) .^ 2) / sw
+    mp /= sw
+    mo /= sw
+    cxy = 0.0
+    vp = 0.0
+    vo = 0.0
+    @inbounds @simd for i in 1:n
+        dp = pred[i] - mp
+        do_ = obs[i] - mo
+        cxy += wt[i] * dp * do_
+        vp += wt[i] * dp * dp
+        vo += wt[i] * do_ * do_
+    end
     # A constant target carries nothing to correlate against, so the group is left out.
     vo <= 0 && return nothing
     # A constant prediction is a failure to discriminate, which scores as no correlation.
     vp <= 0 && return 0.0
-    return sum(wt .* (pred .- mp) .* (obs .- mo)) / sw / sqrt(vp * vo)
+    return cxy / sqrt(vp * vo)
 end
+
+_corr_group(p::AbstractMatrix, y, w::AbstractVector, rows, k::Int) =
+    _corr_group!(Float64[], Float64[], Float64[], p, y, w, rows, k)
+
 
 """
     corr(p, y, w, eval; group, kwargs...)
@@ -221,11 +321,11 @@ weight enters its own group's correlation, and a group weighs by the mean of its
 
 Groups of fewer than two rows, and groups whose target is constant, carry no signal and are
 left out of the average. A group whose prediction is constant while its target is not scores
-zero.
+zero. With multiple targets each is correlated on its own and the group takes their mean.
 """
 function corr(
     p::AbstractMatrix{T},
-    y::AbstractVector,
+    y::AbstractVecOrMat{T},
     w::AbstractVector{T},
     eval::AbstractVector{T};
     group=nothing,
@@ -235,19 +335,14 @@ function corr(
         "`metric = :corr` requires group information. Pass `group_name` or `eval_group_name` " *
         "when fitting from a table, or `group_eval` alongside `x_eval` when fitting from a matrix."
     )
+    # Number of targets, not of prediction rows: an MLE model carries its scale in row 2,
+    # which is not something to correlate against the target.
+    K = y isa AbstractMatrix ? size(y, 1) : 1
     ng = ngroups(group)
     scores = zeros(Float64, ng)
     weights = zeros(Float64, ng)
-    @threads for g in 1:ng
-        rows = group_rows(group, g)
-        pred = [Float64(p[1, r]) for r in rows]
-        obs = [Float64(y[r]) for r in rows]
-        wt = [Float64(w[r]) for r in rows]
-        s = _corr_group(pred, obs, wt)
-        if !isnothing(s)
-            scores[g] = s
-            weights[g] = mean(wt)
-        end
+    @threads for chunk in _group_chunks(ng)
+        _corr_chunk!(scores, weights, p, y, w, group, chunk, K)
     end
     sw = sum(weights)
     sw <= 0 && return zero(Float64)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -142,6 +142,63 @@ function multiquantile(
 end
 
 
+# NDCG within a single group. `pred` and `rel` are the predicted scores and the graded
+# relevances of one group's documents, in matching order.
+function _ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int)
+    n = length(rel)
+    kk = min(k, n)
+    ord = sortperm(pred; rev=true)
+    dcg = 0.0
+    @inbounds for i in 1:kk
+        dcg += (2.0^rel[ord[i]] - 1) / log2(i + 1)
+    end
+    ideal = sort(rel; rev=true)
+    idcg = 0.0
+    @inbounds for i in 1:kk
+        idcg += (2.0^ideal[i] - 1) / log2(i + 1)
+    end
+    # A group whose documents are all irrelevant has no attainable ordering to be scored
+    # against. Scored as 1.0, matching the convention in the LTRC tutorial, so that a group
+    # the model cannot get wrong does not drag the average down.
+    return idcg > 0 ? dcg / idcg : 1.0
+end
+
+"""
+    ndcg(p, y, w, eval; group, ndcg_k, kwargs...)
+
+Normalised discounted cumulative gain, computed **within each group and then averaged over
+groups**, which is what makes it a ranking metric rather than a global one. Requires the
+group index supplied at fit through `group_name` or `group_eval`.
+
+Each group is weighted by the mean of its rows' weights, which reduces to an unweighted mean
+over groups when no weights are given.
+"""
+function ndcg(
+    p::AbstractMatrix{T},
+    y::AbstractVector,
+    w::AbstractVector{T},
+    eval::AbstractVector{T};
+    group=nothing,
+    ndcg_k::Int=typemax(Int),
+    kwargs...
+) where {T}
+    isnothing(group) && error(
+        "`metric = :ndcg` requires group information. Pass `group_name` when fitting from a " *
+        "table, or `group_eval` alongside `x_eval` when fitting from a matrix."
+    )
+    ng = ngroups(group)
+    scores = zeros(Float64, ng)
+    weights = zeros(Float64, ng)
+    @threads for g in 1:ng
+        rows = group_rows(group, g)
+        pred = [p[1, r] for r in rows]
+        rel = [y[r] for r in rows]
+        scores[g] = _ndcg_group(pred, rel, ndcg_k)
+        weights[g] = mean(w[r] for r in rows)
+    end
+    return sum(scores .* weights) / sum(weights)
+end
+
 function gini_raw(p::AbstractVector, y::AbstractVector)
     _y = y .- minimum(y)
     if length(_y) < 2
@@ -190,6 +247,7 @@ const metric_dict = Dict(
     :quantile => wmae,
     :multiquantile => multiquantile,
     :gini => gini,
+    :ndcg => ndcg,
 )
 
 is_maximise(::typeof(mse)) = false
@@ -205,3 +263,4 @@ is_maximise(::typeof(logistic_mle)) = true
 is_maximise(::typeof(wmae)) = false
 is_maximise(::typeof(multiquantile)) = false
 is_maximise(::typeof(gini)) = true
+is_maximise(::typeof(ndcg)) = true

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -142,8 +142,7 @@ function multiquantile(
 end
 
 
-# NDCG within a single group. `pred` and `rel` are the predicted scores and the graded
-# relevances of one group's documents, in matching order.
+# NDCG within a single group, `pred` and `rel` in matching order.
 function _ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int)
     n = length(rel)
     kk = min(k, n)
@@ -157,21 +156,16 @@ function _ndcg_group(pred::AbstractVector, rel::AbstractVector, k::Int)
     @inbounds for i in 1:kk
         idcg += (2.0^ideal[i] - 1) / log2(i + 1)
     end
-    # A group whose documents are all irrelevant has no attainable ordering to be scored
-    # against. Scored as 1.0, matching the convention in the LTRC tutorial, so that a group
-    # the model cannot get wrong does not drag the average down.
+    # All-irrelevant groups score 1.0, matching the convention in the LTRC tutorial.
     return idcg > 0 ? dcg / idcg : 1.0
 end
 
 """
     ndcg(p, y, w, eval; group, ndcg_k, kwargs...)
 
-Normalised discounted cumulative gain, computed **within each group and then averaged over
-groups**, which is what makes it a ranking metric rather than a global one. Requires the
-group index supplied at fit through `group_name` or `group_eval`.
-
-Each group is weighted by the mean of its rows' weights, which reduces to an unweighted mean
-over groups when no weights are given.
+Normalised discounted cumulative gain, computed within each group then averaged over groups.
+Requires the group index supplied at fit through `group_name` or `group_eval`. Each group is
+weighted by the mean of its rows' weights.
 """
 function ndcg(
     p::AbstractMatrix{T},

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -166,7 +166,9 @@ end
 Normalised discounted cumulative gain, computed within each group then averaged over groups.
 Requires the group index supplied at fit through `group_name` or `group_eval`. A group's weight
 is the mean of its rows' weights, so the default of unit weights leaves every group equally
-weighted while relative weights within a group still carry through.
+weighted. Only that group-level weight enters the score: NDCG is defined from the ranking of a
+group's documents, so the spread of weights within a group is deliberately ignored. Use `:corr`
+if per-document weights need to count.
 """
 function ndcg(
     p::AbstractMatrix{T},
@@ -192,6 +194,64 @@ function ndcg(
         weights[g] = mean(w[r] for r in rows)
     end
     return sum(scores .* weights) / sum(weights)
+end
+
+function _corr_group(pred::AbstractVector, obs::AbstractVector, wt::AbstractVector)
+    length(pred) < 2 && return nothing
+    sw = sum(wt)
+    sw <= 0 && return nothing
+    mp = sum(wt .* pred) / sw
+    mo = sum(wt .* obs) / sw
+    vp = sum(wt .* (pred .- mp) .^ 2) / sw
+    vo = sum(wt .* (obs .- mo) .^ 2) / sw
+    # A constant target carries nothing to correlate against, so the group is left out.
+    vo <= 0 && return nothing
+    # A constant prediction is a failure to discriminate, which scores as no correlation.
+    vp <= 0 && return 0.0
+    return sum(wt .* (pred .- mp) .* (obs .- mo)) / sw / sqrt(vp * vo)
+end
+
+"""
+    corr(p, y, w, eval; group, kwargs...)
+
+Weighted Pearson correlation between prediction and target, computed within each group then
+averaged over groups. Requires the group index supplied at fit through `group_name`,
+`eval_group_name` or `group_eval`. Unlike `:ndcg` this uses weights at both levels: a row's
+weight enters its own group's correlation, and a group weighs by the mean of its rows' weights.
+
+Groups of fewer than two rows, and groups whose target is constant, carry no signal and are
+left out of the average. A group whose prediction is constant while its target is not scores
+zero.
+"""
+function corr(
+    p::AbstractMatrix{T},
+    y::AbstractVector,
+    w::AbstractVector{T},
+    eval::AbstractVector{T};
+    group=nothing,
+    kwargs...
+) where {T}
+    isnothing(group) && error(
+        "`metric = :corr` requires group information. Pass `group_name` or `eval_group_name` " *
+        "when fitting from a table, or `group_eval` alongside `x_eval` when fitting from a matrix."
+    )
+    ng = ngroups(group)
+    scores = zeros(Float64, ng)
+    weights = zeros(Float64, ng)
+    @threads for g in 1:ng
+        rows = group_rows(group, g)
+        pred = [Float64(p[1, r]) for r in rows]
+        obs = [Float64(y[r]) for r in rows]
+        wt = [Float64(w[r]) for r in rows]
+        s = _corr_group(pred, obs, wt)
+        if !isnothing(s)
+            scores[g] = s
+            weights[g] = mean(wt)
+        end
+    end
+    sw = sum(weights)
+    sw <= 0 && return zero(Float64)
+    return sum(scores .* weights) / sw
 end
 
 function gini_raw(p::AbstractVector, y::AbstractVector)
@@ -243,6 +303,7 @@ const metric_dict = Dict(
     :multiquantile => multiquantile,
     :gini => gini,
     :ndcg => ndcg,
+    :corr => corr,
 )
 
 is_maximise(::typeof(mse)) = false
@@ -259,3 +320,4 @@ is_maximise(::typeof(wmae)) = false
 is_maximise(::typeof(multiquantile)) = false
 is_maximise(::typeof(gini)) = true
 is_maximise(::typeof(ndcg)) = true
+is_maximise(::typeof(corr)) = true

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -164,8 +164,9 @@ end
     ndcg(p, y, w, eval; group, ndcg_k, kwargs...)
 
 Normalised discounted cumulative gain, computed within each group then averaged over groups.
-Requires the group index supplied at fit through `group_name` or `group_eval`. Each group is
-weighted by the mean of its rows' weights.
+Requires the group index supplied at fit through `group_name` or `group_eval`. A group's weight
+is the sum of its rows' weights, so per-observation weights aggregate to a query weight and the
+default of unit weights makes a group count in proportion to its size.
 """
 function ndcg(
     p::AbstractMatrix{T},
@@ -188,7 +189,7 @@ function ndcg(
         pred = [p[1, r] for r in rows]
         rel = [y[r] for r in rows]
         scores[g] = _ndcg_group(pred, rel, ndcg_k)
-        weights[g] = mean(w[r] for r in rows)
+        weights[g] = sum(w[r] for r in rows)
     end
     return sum(scores .* weights) / sum(weights)
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -51,7 +51,7 @@ abstract type Cache end
 abstract type CacheCPU <: Cache end
 abstract type CacheGPU <: Cache end
 
-struct CacheBaseCPU{Y,N<:TrainNode,H<:AbstractArray{<:AbstractFloat,4}} <: CacheCPU
+struct CacheBaseCPU{Y,N<:TrainNode,H<:AbstractArray{<:AbstractFloat,4},G} <: CacheCPU
     rng::Xoshiro
     K::UInt8
     x_bin::Matrix{UInt8}
@@ -71,6 +71,7 @@ struct CacheBaseCPU{Y,N<:TrainNode,H<:AbstractArray{<:AbstractFloat,4}} <: Cache
     featbins::Vector{UInt8}
     feattypes::Vector{Bool}
     monotone_constraints::Vector{Int32}
+    group::G
 end
 
 # single tree is made of a vectors of length num nodes

--- a/src/subsample.jl
+++ b/src/subsample.jl
@@ -37,6 +37,34 @@ function subsample(left::AbstractVector, is::AbstractVector, mask_cond::Abstract
     return view(is, 1:counts_sum)
 end
 
+"""
+    subsample(left, is, mask_cond, rowsample, rng, gi::GroupIndex)
+
+Group-aware variant used for ranking tasks. Draws one value per group rather than per row,
+so a selected group contributes all of its rows and is never split. Sampling whole groups is
+required for any objective or metric defined within a group: a partial group changes the
+comparison set, and so changes the quantity being optimised.
+
+Returns a view of selected row ids, ordered by group.
+"""
+function subsample(left::AbstractVector, is::AbstractVector, mask_cond::AbstractVector{UInt8}, rowsample::AbstractFloat, rng, gi::GroupIndex)
+    ng = ngroups(gi)
+    mask = view(mask_cond, 1:ng)
+    Random.rand!(rng, mask)
+    cond = round(UInt8, 255 * rowsample)
+    count = 0
+    @inbounds for g in 1:ng
+        if mask[g] <= cond
+            for r in group_rows(gi, g)
+                count += 1
+                is[count] = r
+            end
+        end
+    end
+    count == 0 && error("no subsample group - choose larger rowsample")
+    return view(is, 1:count)
+end
+
 # function subsample_single(is_in::AbstractVector, out::AbstractVector, mask::AbstractVector, rowsample::AbstractFloat, rng)
 #     Random.rand!(rng, mask)
 #     cond = round(UInt8, 255 * rowsample)

--- a/src/subsample.jl
+++ b/src/subsample.jl
@@ -40,10 +40,9 @@ end
 """
     subsample(left, is, mask_cond, rowsample, rng, gi::GroupIndex)
 
-Group-aware variant used for ranking tasks. Draws one value per group rather than per row,
-so a selected group contributes all of its rows and is never split. Sampling whole groups is
-required for any objective or metric defined within a group: a partial group changes the
-comparison set, and so changes the quantity being optimised.
+Group-aware variant for ranking. Draws one value per group rather than per row, so a
+selected group is never split: a partial group changes the comparison set a group-defined
+objective or metric is computed over.
 
 Returns a view of selected row ids, ordered by group.
 """

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -313,19 +313,25 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
         # The reported metric must equal the per-group NDCG a user would compute by hand,
         # which is what the LTRC tutorial does with a `groupby`. This is the check that the
         # metric is a ranking metric rather than a global one.
-        # A group's weight is the mean of its rows' weights, so unit weights leave groups
-        # equally weighted while relative weights within a group still carry through.
+        # A group's weight is the mean of its rows' weights. The two groups must score
+        # differently and the weights must not be uniform, otherwise every candidate rule
+        # gives the same answer and the assertion pins nothing.
         let
             q = [1, 1, 1, 2, 2]
             rel = Float32[3, 1, 0, 2, 0]
-            pr = reshape(Float32[3, 2, 1, 2, 1], 1, 5)
+            pr = reshape(Float32[1, 2, 3, 2, 1], 1, 5)   # group 1 ranked badly, group 2 perfectly
             gi = build_group_index(q)
-            wv = Float32[0.2, 0.5, 0.3, 0.8, 0.8]
+            wv = Float32[1, 1, 4, 3, 3]
             got = EvoTrees.ndcg(pr, rel, wv, Float32[]; group=gi, ndcg_k=10)
-            s1 = EvoTrees._ndcg_group(Float64[3, 2, 1], Float64[3, 1, 0], 10)
+            s1 = EvoTrees._ndcg_group(Float64[1, 2, 3], Float64[3, 1, 0], 10)
             s2 = EvoTrees._ndcg_group(Float64[2, 1], Float64[2, 0], 10)
-            wA, wB = (0.2 + 0.5 + 0.3) / 3, (0.8 + 0.8) / 2
-            @test got ≈ (s1 * wA + s2 * wB) / (wA + wB) rtol = 1e-5
+            @test s1 != s2
+            agg(f) = (s1 * f(Float64[1, 1, 4]) + s2 * f(Float64[3, 3])) / (f(Float64[1, 1, 4]) + f(Float64[3, 3]))
+            @test got ≈ agg(mean) rtol = 1e-5
+            # and the rule is pinned: sum, maximum and minimum all give something else
+            for other in (sum, maximum, minimum)
+                @test !isapprox(got, agg(other); rtol = 1e-3)
+            end
         end
 
         function tutorial_ndcg(p, target, k=10)

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -167,6 +167,35 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         @test all(iszero, ∇0[1:2, :])
     end
 
+    @testset "eval-only grouping" begin
+        # Training with the usual per-row sampling while evaluating a group-aware metric.
+        # `eval_group_name` defaults to `group_name`, and set on its own it leaves training
+        # ungrouped.
+        rng = Xoshiro(21)
+        nobs = 1_500
+        q = repeat(1:150, inner=10)
+        x = rand(rng, nobs, 3)
+        y = clamp.(round.(2 .* x[:, 1] .+ randn(rng, nobs)), 0, 4)
+        tr, te = 1:1_000, 1_001:nobs
+        dtrain = (q=q[tr], f1=x[tr, 1], f2=x[tr, 2], f3=x[tr, 3], y=y[tr])
+        deval = (q=q[te], f1=x[te, 1], f2=x[te, 2], f3=x[te, 3], y=y[te])
+
+        cfg = EvoTreeRegressor(; loss=:mse, metric=:ndcg, ndcg_k=10, nrounds=20,
+            max_depth=4, rowsample=0.5)
+        m = fit(cfg, dtrain; target_name=:y, eval_group_name=:q, deval, verbosity=0)
+
+        # training saw no groups, so `q` is just another feature unless excluded by name
+        @test :q in m.info[:feature_names]
+        mets = m.info[:logger][:metrics]
+        @test all(0 .<= mets .<= 1)
+        @test length(mets) == 21
+
+        # and it still defaults to `group_name` when only that is given
+        m2 = fit(cfg, dtrain; target_name=:y, group_name=:q, deval, verbosity=0)
+        @test m2.info[:group_name] == :q
+        @test all(0 .<= m2.info[:logger][:metrics] .<= 1)
+    end
+
     @testset "fit with lambdarank" begin
         # Each query grades on its own curve, so absolute label level is query-specific
         # noise that regression must fit but a ranking objective can ignore.

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -387,9 +387,9 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
         @test unit != wtd
 
         # groups carrying no signal are left out rather than averaged in as zero
-        @test isnothing(_corr_group(Float64[1.0], Float64[2.0], Float64[1.0]))
-        @test isnothing(_corr_group(Float64[1, 2, 3], Float64[5, 5, 5], ones(3)))
-        @test _corr_group(Float64[2, 2, 2], Float64[1, 2, 3], ones(3)) == 0.0
+        @test isnothing(_corr_group(reshape([1.0], 1, 1), [2.0], [1.0], 1:1, 1))
+        @test isnothing(_corr_group(reshape(Float64[1, 2, 3], 1, 3), Float64[5, 5, 5], ones(3), 1:3, 1))
+        @test _corr_group(reshape(Float64[2, 2, 2], 1, 3), Float64[1, 2, 3], ones(3), 1:3, 1) == 0.0
         q2 = UInt32[1, 1, 1, 2, 2, 2]
         y2 = Float32[1, 2, 3, 7, 7, 7]
         got2 = corr(reshape(Float32[1, 2, 3, 1, 2, 3], 1, :), y2, ones(Float32, 6), Float32[];

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -145,8 +145,8 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
             D = pair_deltas(sc, rel, k)
             ∇ = zeros(Float32, 3, n)
             ∇[3, :] .= 1
-            EvoTrees._lambdarank_group!(∇, reshape(Float32.(sc), 1, n), Float32.(rel),
-                collect(1:n), k)
+            EvoTrees._lambdarank_group!(EvoTrees.LambdaRankScratch(), ∇,
+                reshape(Float32.(sc), 1, n), Float32.(rel), collect(1:n), k)
             h = 1e-6
             for i in 1:n
                 sp = copy(sc); sp[i] += h
@@ -162,8 +162,8 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
         # A query with no relevant document carries no ranking signal.
         ∇0 = zeros(Float32, 3, 4)
         ∇0[3, :] .= 1
-        EvoTrees._lambdarank_group!(∇0, reshape(Float32[4, 3, 2, 1], 1, 4),
-            Float32[0, 0, 0, 0], collect(1:4), 10)
+        EvoTrees._lambdarank_group!(EvoTrees.LambdaRankScratch(), ∇0,
+            reshape(Float32[4, 3, 2, 1], 1, 4), Float32[0, 0, 0, 0], collect(1:4), 10)
         @test all(iszero, ∇0[1:2, :])
     end
 

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -111,6 +111,112 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         @test any(!iszero, ∇2)
     end
 
+    @testset "lambdarank gradients" begin
+        # |dNDCG| is held constant wrt the scores, so the gradient must equal dC/ds for
+        # C = sum over pairs rel_a > rel_b of |dNDCG_ab| * log(1 + exp(-(s_a - s_b))).
+        function pair_deltas(scores, rel, k)
+            n = length(rel)
+            ideal = sort(rel; rev=true)
+            maxdcg = sum((2.0^ideal[i] - 1) / log2(i + 1) for i in 1:min(k, n))
+            ord = sortperm(scores; rev=true)
+            rank = zeros(Int, n)
+            for pos in 1:n
+                rank[ord[pos]] = pos
+            end
+            disc = [pos <= k ? 1 / log2(pos + 1) : 0.0 for pos in 1:n]
+            D = zeros(n, n)
+            for a in 1:n, b in 1:n
+                rel[a] > rel[b] || continue
+                D[a, b] = abs((2.0^rel[a] - 2.0^rel[b]) *
+                              (disc[rank[a]] - disc[rank[b]])) / maxdcg
+            end
+            D
+        end
+        pair_cost(s, D, rel) = sum(
+            D[a, b] * log(1 + exp(-(s[a] - s[b])))
+            for a in eachindex(rel), b in eachindex(rel) if rel[a] > rel[b])
+
+        rng = Xoshiro(3)
+        for _ in 1:3, k in (3, 10)
+            n = 7
+            rel = Float64.(rand(rng, 0:4, n))
+            length(unique(rel)) < 2 && continue
+            sc = randn(rng, n)
+            D = pair_deltas(sc, rel, k)
+            ∇ = zeros(Float32, 3, n)
+            ∇[3, :] .= 1
+            EvoTrees._lambdarank_group!(∇, reshape(Float32.(sc), 1, n), Float32.(rel),
+                collect(1:n), k)
+            h = 1e-6
+            for i in 1:n
+                sp = copy(sc); sp[i] += h
+                sm = copy(sc); sm[i] -= h
+                @test ∇[1, i] ≈ (pair_cost(sp, D, rel) - pair_cost(sm, D, rel)) / (2h) atol = 1e-5
+            end
+            @test all(∇[2, :] .>= 0)
+            @test all(isfinite, ∇[1:2, :])
+            # Pairwise contributions are antisymmetric, so a query's gradients cancel.
+            @test sum(∇[1, :]) ≈ 0 atol = 1e-5
+        end
+
+        # A query with no relevant document carries no ranking signal.
+        ∇0 = zeros(Float32, 3, 4)
+        ∇0[3, :] .= 1
+        EvoTrees._lambdarank_group!(∇0, reshape(Float32[4, 3, 2, 1], 1, 4),
+            Float32[0, 0, 0, 0], collect(1:4), 10)
+        @test all(iszero, ∇0[1:2, :])
+    end
+
+    @testset "fit with lambdarank" begin
+        # Each query grades on its own curve, so absolute label level is query-specific
+        # noise that regression must fit but a ranking objective can ignore.
+        rng = Xoshiro(7)
+        qid = Int[]
+        rows = Vector{Float64}[]
+        rel = Float64[]
+        for q in 1:600
+            shift = 2.5 * randn(rng)
+            for _ in 1:rand(rng, 8:16)
+                f = randn(rng, 4)
+                sc = 1.5f[1] - f[2] + 0.5f[1] * f[3] + randn(rng)
+                push!(qid, q)
+                push!(rows, f)
+                push!(rel, clamp(round(sc + shift + 2), 0, 4))
+            end
+        end
+        x = permutedims(reduce(hcat, rows))
+        y = rel
+        tr, te = qid .<= 450, qid .> 450
+
+        # Both report `:ndcg` so the two are comparable; `:mse` would otherwise default to
+        # reporting squared error.
+        cfg(loss) = EvoTreeRegressor(; loss, metric=:ndcg, ndcg_k=10, nrounds=150,
+            max_depth=5, eta=0.05, rowsample=0.7)
+        fitted(loss) = fit(cfg(loss); x_train=x[tr, :], y_train=y[tr], group_train=qid[tr],
+            x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
+
+        m = fitted(:lambdarank)
+        @test EvoTreeRegressor(; loss=:lambdarank).metric == :ndcg
+        mets = m.info[:logger][:metrics]
+        @test all(0 .<= mets .<= 1)
+        @test mets[end] > mets[1]
+
+        # Whether the ranking objective beats regression is an empirical property that
+        # depends on the data and sample size, so it belongs in a benchmark rather than
+        # here. What is asserted is that it optimises something different: the two produce
+        # materially different models on the same inputs.
+        pl = predict(m, x[te, :])
+        pm = predict(fitted(:mse), x[te, :])
+        @test cor(pl, pm) < 0.999
+
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; loss=:lambdarank, nrounds=5, max_depth=3);
+            x_train=x[tr, :], y_train=y[tr], verbosity=0)
+        @test_throws AssertionError fit(
+            EvoTreeRegressor(; loss=:lambdarank, nrounds=5, max_depth=3);
+            x_train=x[tr, :], y_train=y[tr] .- 1, group_train=qid[tr], verbosity=0)
+    end
+
     @testset "fit with groups" begin
         rng = Xoshiro(42)
         nq = 300

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -2,7 +2,7 @@ using Test
 using Statistics
 using Random
 using EvoTrees
-using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
+using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample, corr, _corr_group
 
 @testset "ranking groups" begin
 
@@ -348,6 +348,67 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
             ye, qe = y[te], qid[te]
             manual = mean(tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in unique(qe))
             @test mk.info[:logger][:metrics][end] ≈ manual rtol = 1e-6
+        end
+    end
+
+
+    @testset "grouped correlation" begin
+        # Weighted Pearson within each group, averaged over groups. Unlike `:ndcg` a row's own
+        # weight enters its group's score, so both levels of weighting are live.
+        function wpearson(x, y, w)
+            sw = sum(w)
+            mx, my = sum(w .* x) / sw, sum(w .* y) / sw
+            cxy = sum(w .* (x .- mx) .* (y .- my)) / sw
+            vx = sum(w .* (x .- mx) .^ 2) / sw
+            vy = sum(w .* (y .- my) .^ 2) / sw
+            return cxy / sqrt(vx * vy)
+        end
+
+        q = UInt32[1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3]
+        pv = Float64[3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8]
+        yv = Float64[2, 1, 5, 1, 6, 1, 9, 4, 5, 4, 4, 9]
+        wv = Float64[1, 2, 1, 3, 1, 2, 1, 1, 1, 1, 4, 2]
+        gi = build_group_index(q)
+        for w in (ones(length(q)), wv)
+            got = corr(reshape(Float32.(pv), 1, :), Float32.(yv), Float32.(w), Float32[]; group=gi)
+            cs = [wpearson(pv[q.==g], yv[q.==g], w[q.==g]) for g in 1:3]
+            ws = [mean(w[q.==g]) for g in 1:3]
+            @test got ≈ sum(cs .* ws) / sum(ws) rtol = 1e-5
+        end
+        # per-row weights move the score, which is the difference from `:ndcg`
+        unit = corr(reshape(Float32.(pv), 1, :), Float32.(yv), ones(Float32, 12), Float32[]; group=gi)
+        wtd = corr(reshape(Float32.(pv), 1, :), Float32.(yv), Float32.(wv), Float32[]; group=gi)
+        @test unit != wtd
+
+        # groups carrying no signal are left out rather than averaged in as zero
+        @test isnothing(_corr_group(Float64[1.0], Float64[2.0], Float64[1.0]))
+        @test isnothing(_corr_group(Float64[1, 2, 3], Float64[5, 5, 5], ones(3)))
+        @test _corr_group(Float64[2, 2, 2], Float64[1, 2, 3], ones(3)) == 0.0
+        q2 = UInt32[1, 1, 1, 2, 2, 2]
+        y2 = Float32[1, 2, 3, 7, 7, 7]
+        got2 = corr(reshape(Float32[1, 2, 3, 1, 2, 3], 1, :), y2, ones(Float32, 6), Float32[];
+            group=build_group_index(q2))
+        @test got2 ≈ 1.0 rtol = 1e-6
+
+        @test EvoTrees.is_maximise(corr)
+        @test_throws ErrorException corr(reshape(Float32.(pv), 1, :), Float32.(yv),
+            ones(Float32, 12), Float32[])
+
+        # the maintainer's case: train ungrouped, track a grouped correlation
+        rng = Xoshiro(2)
+        nobs = 1_500
+        g = repeat(1:150, inner=10)
+        x = rand(rng, nobs, 3)
+        y = 2 .* x[:, 1] .+ 0.3 .* randn(rng, nobs)
+        tr, te = 1:1_000, 1_001:nobs
+        dtr = (q=g[tr], f1=x[tr, 1], f2=x[tr, 2], f3=x[tr, 3], y=y[tr])
+        dev = (q=g[te], f1=x[te, 1], f2=x[te, 2], f3=x[te, 3], y=y[te])
+        for cfg in (EvoTreeRegressor(loss=:mse, metric=:corr, nrounds=25, max_depth=4, rowsample=0.5),
+            EvoTreeMLE(loss=:gaussian_mle, metric=:corr, nrounds=20, max_depth=4))
+            m = fit(cfg, dtr; target_name=:y, eval_group_name=:q, deval=dev, verbosity=0)
+            mets = m.info[:logger][:metrics]
+            @test all(-1 .<= mets .<= 1)
+            @test mets[end] > 0.5
         end
     end
 

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -284,9 +284,8 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         # The reported metric must equal the per-group NDCG a user would compute by hand,
         # which is what the LTRC tutorial does with a `groupby`. This is the check that the
         # metric is a ranking metric rather than a global one.
-        # A group's weight is the sum of its rows' weights, so per-observation weights
-        # aggregate to a query weight. Jeremie's example: A of 0.2/0.5/0.3 weighs 1.0 and
-        # B of 0.8/0.8 weighs 1.6.
+        # A group's weight is the mean of its rows' weights, so unit weights leave groups
+        # equally weighted while relative weights within a group still carry through.
         let
             q = [1, 1, 1, 2, 2]
             rel = Float32[3, 1, 0, 2, 0]
@@ -296,7 +295,8 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
             got = EvoTrees.ndcg(pr, rel, wv, Float32[]; group=gi, ndcg_k=10)
             s1 = EvoTrees._ndcg_group(Float64[3, 2, 1], Float64[3, 1, 0], 10)
             s2 = EvoTrees._ndcg_group(Float64[2, 1], Float64[2, 0], 10)
-            @test got ≈ (s1 * 1.0 + s2 * 1.6) / 2.6 rtol = 1e-5
+            wA, wB = (0.2 + 0.5 + 0.3) / 3, (0.8 + 0.8) / 2
+            @test got ≈ (s1 * wA + s2 * wB) / (wA + wB) rtol = 1e-5
         end
 
         function tutorial_ndcg(p, target, k=10)
@@ -317,12 +317,8 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
                 x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
             p = predict(mk, x[te, :])
             ye, qe = y[te], qid[te]
-            # A group's weight is the sum of its rows' weights, so with unit weights the
-            # average over queries is weighted by query size rather than uniform.
-            qs = unique(qe)
-            sc = [tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in qs]
-            sz = [count(==(q), qe) for q in qs]
-            @test mk.info[:logger][:metrics][end] ≈ sum(sc .* sz) / sum(sz) rtol = 1e-6
+            manual = mean(tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in unique(qe))
+            @test mk.info[:logger][:metrics][end] ≈ manual rtol = 1e-6
         end
     end
 

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -83,6 +83,34 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         @test length(sel) == n
     end
 
+    @testset "loss reaches the group index" begin
+        # Every loss defined today is per observation and ignores groups, but a group
+        # defined objective such as LambdaRank needs the index at the call site. The
+        # forwarding method makes that reachable without touching any existing loss.
+        struct _GroupProbeLoss <: EvoTrees.LossType end
+        seen = Ref{Any}(:unset)
+        # `params` is constrained the same way every loss in `src/loss.jl` constrains it;
+        # leaving it untyped would be ambiguous against the forwarding method.
+        EvoTrees.update_grads!(∇, p, y, ::Type{_GroupProbeLoss}, params::EvoTrees.EvoTypes, group) =
+            (seen[] = group; nothing)
+
+        gi = build_group_index([1, 1, 2, 2, 2])
+        ∇ = zeros(Float32, 3, 5)
+        p = zeros(Float32, 1, 5)
+        EvoTrees.update_grads!(∇, p, zeros(Float32, 5), _GroupProbeLoss,
+            EvoTreeRegressor(; nrounds=1), gi)
+        @test seen[] === gi
+
+        # And a loss that does not define the six argument form still works, receiving
+        # nothing and dispatching to its existing method.
+        ∇2 = zeros(Float32, 3, 5)
+        ∇2[3, :] .= 1        # weight row; gradients are scaled by it
+        p2 = zeros(Float32, 1, 5)
+        EvoTrees.update_grads!(∇2, p2, Float32[1, 2, 3, 4, 5], EvoTrees.MSE,
+            EvoTreeRegressor(; nrounds=1), nothing)
+        @test any(!iszero, ∇2)
+    end
+
     @testset "fit with groups" begin
         rng = Xoshiro(42)
         nq = 300
@@ -123,6 +151,23 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         @test mt.info[:feature_names] == [:f1, :f2, :f3, :f4]
         @test mt.info[:group_name] == :q
         @test mt.info[:logger][:metrics][end] > mt.info[:logger][:metrics][1]
+
+        # A group column of the wrong length must be rejected. A short one would otherwise
+        # silently train or score on a subset and report the result as if it covered
+        # everything; a long one indexes past the end of the predictions.
+        ntr, nte = sum(tr), sum(te)
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; nrounds=5, max_depth=3, metric=:ndcg);
+            x_train=x[tr, :], y_train=y[tr], group_train=qid[tr][1:(ntr÷2)],
+            x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; nrounds=5, max_depth=3, metric=:ndcg);
+            x_train=x[tr, :], y_train=y[tr], group_train=qid[tr],
+            x_eval=x[te, :], y_eval=y[te], group_eval=qid[te][1:(nte÷2)], verbosity=0)
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; nrounds=5, max_depth=3, metric=:ndcg);
+            x_train=x[tr, :], y_train=y[tr], group_train=qid[tr],
+            x_eval=x[te, :], y_eval=y[te], group_eval=qid, verbosity=0)
 
         # Without groups there is nothing to rank within, so `:ndcg` must say so rather
         # than silently scoring the whole eval set as one list.

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -130,11 +130,6 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
             EvoTreeRegressor(; nrounds=5, max_depth=3, metric=:ndcg),
             dtrain; target_name=:y, deval, verbosity=0)
 
-        # Group-aware training is CPU only for now, and says so.
-        @test_throws ErrorException fit(
-            EvoTreeRegressor(; nrounds=5, max_depth=3, device=:gpu),
-            dtrain; target_name=:y, group_name=:q, verbosity=0)
-
         # The reported metric must equal the per-group NDCG a user would compute by hand,
         # which is what the LTRC tutorial does with a `groupby`. This is the check that the
         # metric is a ranking metric rather than a global one.

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -284,6 +284,21 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
         # The reported metric must equal the per-group NDCG a user would compute by hand,
         # which is what the LTRC tutorial does with a `groupby`. This is the check that the
         # metric is a ranking metric rather than a global one.
+        # A group's weight is the sum of its rows' weights, so per-observation weights
+        # aggregate to a query weight. Jeremie's example: A of 0.2/0.5/0.3 weighs 1.0 and
+        # B of 0.8/0.8 weighs 1.6.
+        let
+            q = [1, 1, 1, 2, 2]
+            rel = Float32[3, 1, 0, 2, 0]
+            pr = reshape(Float32[3, 2, 1, 2, 1], 1, 5)
+            gi = build_group_index(q)
+            wv = Float32[0.2, 0.5, 0.3, 0.8, 0.8]
+            got = EvoTrees.ndcg(pr, rel, wv, Float32[]; group=gi, ndcg_k=10)
+            s1 = EvoTrees._ndcg_group(Float64[3, 2, 1], Float64[3, 1, 0], 10)
+            s2 = EvoTrees._ndcg_group(Float64[2, 1], Float64[2, 0], 10)
+            @test got ≈ (s1 * 1.0 + s2 * 1.6) / 2.6 rtol = 1e-5
+        end
+
         function tutorial_ndcg(p, target, k=10)
             k = min(k, length(p))
             p_order = partialsortperm(p, 1:k; rev=true)

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -1,0 +1,164 @@
+using Test
+using Statistics
+using Random
+using EvoTrees
+using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
+
+@testset "ranking groups" begin
+
+    @testset "group index" begin
+        # Groups are supplied as a per-row id column, so the rows of a group need not be
+        # contiguous, sorted, or numeric. The index must recover them regardless.
+        raw = [3, 1, 3, 2, 1, 3]
+        gi = build_group_index(raw)
+
+        @test ngroups(gi) == 3
+        @test length(gi) == 6
+        # Ids are normalised to 1:ngroups by sorted level, so 1 -> 1, 2 -> 2, 3 -> 3.
+        @test gi.group == UInt32[3, 1, 3, 2, 1, 3]
+        # Every row belongs to exactly one group, and none is lost.
+        @test sort(Int.(gi.rows)) == collect(1:6)
+        @test sort(Int.(group_rows(gi, 1))) == [2, 5]
+        @test sort(Int.(group_rows(gi, 2))) == [4]
+        @test sort(Int.(group_rows(gi, 3))) == [1, 3, 6]
+
+        # Non-numeric ids work the same way.
+        gs = build_group_index(["b", "a", "b"])
+        @test ngroups(gs) == 2
+        @test sort(Int.(group_rows(gs, 1))) == [2]      # "a"
+        @test sort(Int.(group_rows(gs, 2))) == [1, 3]   # "b"
+
+        @test_throws ErrorException build_group_index(Int[])
+    end
+
+    @testset "ndcg" begin
+        ndcg_group = EvoTrees._ndcg_group
+        rel = [3.0, 2, 3, 0, 1, 2]
+        desc = Float64.(collect(6:-1:1))   # scores that reproduce `rel`'s given order
+
+        # Hand computation: gains 2^r - 1, discounts log2(i+1).
+        gains = [7.0, 3, 7, 0, 1, 3]
+        disc = [log2(i + 1) for i in 1:6]
+        expected = sum(gains ./ disc) / sum(sort(gains; rev=true) ./ disc)
+        @test ndcg_group(desc, rel, 100) ≈ expected
+
+        @test ndcg_group(Float64.(rel), rel, 100) ≈ 1.0          # perfect ordering
+        @test ndcg_group(-Float64.(rel), rel, 100) < 1.0         # reversed is worse
+        @test ndcg_group([1.0], [2.0], 100) ≈ 1.0                # single document
+        # A group whose documents are all irrelevant cannot be ranked wrongly, and is
+        # scored 1.0 to match the convention used in the LTRC tutorial.
+        @test ndcg_group([3.0, 2, 1], [0.0, 0, 0], 100) == 1.0
+        # Ties in the prediction must not error.
+        @test ndcg_group([1.0, 1.0, 1.0], [2.0, 1.0, 0.0], 100) isa Float64
+
+        # Truncation is bounded by the group size, so k beyond it changes nothing.
+        @test ndcg_group(desc, rel, 6) ≈ ndcg_group(desc, rel, 100)
+        @test ndcg_group(desc, rel, 1) ≈ 1.0    # top document is maximally relevant
+    end
+
+    @testset "group-aware sampling" begin
+        # A group is the unit a ranking objective or metric is defined over, so sampling
+        # must take whole groups. A split group changes the comparison set.
+        rng = Xoshiro(4)
+        qid = repeat(1:60, inner=8)[randperm(rng, 480)]
+        gi = build_group_index(qid)
+        n = length(qid)
+
+        for rowsample in (0.3, 0.5, 0.8)
+            is, left, mask = zeros(UInt32, n), zeros(UInt32, n), zeros(UInt8, n)
+            sel = subsample(left, is, mask, rowsample, Xoshiro(1), gi)
+            picked = unique(gi.group[sel])
+            @test !isempty(picked)
+            # every picked group contributes all of its rows, and nothing else appears
+            for g in picked
+                @test count(==(g), gi.group[sel]) == length(group_rows(gi, g))
+            end
+            @test length(sel) == sum(length(group_rows(gi, g)) for g in picked)
+            @test allunique(sel)
+        end
+
+        # rowsample = 1 keeps every group.
+        is, left, mask = zeros(UInt32, n), zeros(UInt32, n), zeros(UInt8, n)
+        sel = subsample(left, is, mask, 1.0, Xoshiro(1), gi)
+        @test length(sel) == n
+    end
+
+    @testset "fit with groups" begin
+        rng = Xoshiro(42)
+        nq = 300
+        qid = Int[]
+        rows = Vector{Float64}[]
+        rel = Float64[]
+        for q in 1:nq
+            for _ in 1:rand(rng, 8:16)
+                f = randn(rng, 4)
+                s = 1.5f[1] - f[2] + 0.5f[1] * f[3] + 1.2randn(rng)
+                push!(qid, q)
+                push!(rows, f)
+                push!(rel, clamp(round(s + 2), 0, 4))
+            end
+        end
+        x = permutedims(reduce(hcat, rows))
+        y = rel
+        tr = qid .<= 220
+        te = .!tr
+
+        # Matrix API.
+        m = fit(
+            EvoTreeRegressor(; nrounds=80, max_depth=5, eta=0.05, rowsample=0.7,
+                metric=:ndcg, ndcg_k=10);
+            x_train=x[tr, :], y_train=y[tr], group_train=qid[tr],
+            x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
+        mets = m.info[:logger][:metrics]
+        @test all(0 .<= mets .<= 1)
+        @test mets[end] > mets[1]
+
+        # Table API. The group column must not be picked up as a feature.
+        dtrain = (q=qid[tr], f1=x[tr, 1], f2=x[tr, 2], f3=x[tr, 3], f4=x[tr, 4], y=y[tr])
+        deval = (q=qid[te], f1=x[te, 1], f2=x[te, 2], f3=x[te, 3], f4=x[te, 4], y=y[te])
+        mt = fit(
+            EvoTreeRegressor(; nrounds=80, max_depth=5, eta=0.05, rowsample=0.7,
+                metric=:ndcg, ndcg_k=10),
+            dtrain; target_name=:y, group_name=:q, deval, verbosity=0)
+        @test mt.info[:feature_names] == [:f1, :f2, :f3, :f4]
+        @test mt.info[:group_name] == :q
+        @test mt.info[:logger][:metrics][end] > mt.info[:logger][:metrics][1]
+
+        # Without groups there is nothing to rank within, so `:ndcg` must say so rather
+        # than silently scoring the whole eval set as one list.
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; nrounds=5, max_depth=3, metric=:ndcg),
+            dtrain; target_name=:y, deval, verbosity=0)
+
+        # Group-aware training is CPU only for now, and says so.
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(; nrounds=5, max_depth=3, device=:gpu),
+            dtrain; target_name=:y, group_name=:q, verbosity=0)
+
+        # The reported metric must equal the per-group NDCG a user would compute by hand,
+        # which is what the LTRC tutorial does with a `groupby`. This is the check that the
+        # metric is a ranking metric rather than a global one.
+        function tutorial_ndcg(p, target, k=10)
+            k = min(k, length(p))
+            p_order = partialsortperm(p, 1:k; rev=true)
+            gains = 2 .^ target[p_order] .- 1
+            discounts = log2.((1:k) .+ 1)
+            dcg = sum(gains ./ discounts)
+            y_order = partialsortperm(target, 1:k; rev=true)
+            idcg = sum((2 .^ target[y_order] .- 1) ./ discounts)
+            return idcg == 0 ? 1.0 : dcg / idcg
+        end
+
+        for k in (5, 10, typemax(Int))
+            mk = fit(
+                EvoTreeRegressor(; nrounds=30, max_depth=4, eta=0.1, metric=:ndcg, ndcg_k=k);
+                x_train=x[tr, :], y_train=y[tr], group_train=qid[tr],
+                x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
+            p = predict(mk, x[te, :])
+            ye, qe = y[te], qid[te]
+            manual = mean(tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in unique(qe))
+            @test mk.info[:logger][:metrics][end] ≈ manual rtol = 1e-6
+        end
+    end
+
+end

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -317,8 +317,12 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample
                 x_eval=x[te, :], y_eval=y[te], group_eval=qid[te], verbosity=0)
             p = predict(mk, x[te, :])
             ye, qe = y[te], qid[te]
-            manual = mean(tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in unique(qe))
-            @test mk.info[:logger][:metrics][end] ≈ manual rtol = 1e-6
+            # A group's weight is the sum of its rows' weights, so with unit weights the
+            # average over queries is weighted by query size rather than uniform.
+            qs = unique(qe)
+            sc = [tutorial_ndcg(p[qe.==q], ye[qe.==q], k) for q in qs]
+            sz = [count(==(q), qe) for q in qs]
+            @test mk.info[:logger][:metrics][end] ≈ sum(sc .* sz) / sum(sz) rtol = 1e-6
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ using Test
         include("monotonic.jl")
         include("missings.jl")
         include("multi-target.jl")
+        include("ranking.jl")
     end
 
     @testset "MLJ" begin


### PR DESCRIPTION
Adds group (query) support for ranking on CPU and GPU: a group index through both `fit` entry points, group-aware `rowsample`, per-query NDCG, a LambdaRank objective, and a grouped correlation metric.

Groups are a per-row id column, `group_name` from a table or `group_train` / `group_eval` from matrices. `metric=:ndcg` scores within each group and averages over them, so early stopping tracks ranking quality instead of squared error. `loss=:lambdarank` weights pairs within a query by the NDCG change a swap would cause. The lambdas are per document, so K = 1 and the `2K+1` histogram, split gain and leaf solver are all untouched; the objective is one `update_grads!` method.

Groups are ids rather than XGBoost's `group_ptr_` boundaries, so they can arrive unsorted, non-contiguous or non-numeric and the rows need no pre-sorting. `rowsample` takes whole groups, since splitting one changes the comparison set the objective is computed over. A group with no relevant document scores 1.0, matching the `idcg == 0 ? 1.0 : ...` already in the LTRC tutorial.

`eval_group_name` sets the group column for `deval` alone and defaults to `group_name`, so a model can train with ordinary per-row sampling while a group-aware metric is tracked over queries.

A group's weight is the mean of its rows' weights, so unit weights leave every query equally weighted, matching the per-group weights ranking libraries take. Only that group-level weight reaches `:ndcg`, whose definition is a ranking of the group's documents. Where per-document weights should count, `metric=:corr` scores a weighted Pearson correlation within each group and uses weights at both levels. Groups carrying no signal, under two rows or a constant target, are left out of its average.

NDCG and the lambdas are computed host-side on GPU rather than as a segmented sort over variable-length groups. That keeps the two backends identical rather than merely close, and a device kernel is straightforward to add later if a profile ever asks for one.

On the gradient: holding the NDCG deltas fixed, it matches a finite difference of the pairwise cost to 1e-8 at two truncation levels, hessians are non-negative, and the gradients within a query sum to zero. GPU and CPU come out bit-identical.

Ranking only works through `EvoTrees.fit`. The MLJ interface has no way to pass groups, and the docstrings now say so.

Tests in `test/ranking.jl` cover the index, NDCG against a hand computation, the correlation metric against an independently written weighted Pearson, sampling keeping groups whole, the lambdarank gradient, and both entry points. `benchmarks/Yahoo-LTRC.jl` gains a lambdarank section alongside the existing ones, and `benchmarks/pythoncall/ranking.jl` compares both libraries on identical data and groups across a group-size sweep.
