### PR TITLE
Error when prediction data column count does not match the model

### DIFF
--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -64,6 +64,10 @@ end
 Transform feature data into a UInt8 binarized matrix.
 """
 function binarize(X::AbstractMatrix; feature_names, edges)
+    size(X, 2) == length(feature_names) || error(
+        "Data has $(size(X, 2)) columns but the model expects $(length(feature_names)) " *
+        "features: $(feature_names)."
+    )
     x_bin = zeros(UInt8, size(X))
     @threads for j in axes(X, 2)
         x_bin[:, j] .= searchsortedfirst.(Ref(edges[j]), view(X, :, j))

--- a/test/core.jl
+++ b/test/core.jl
@@ -594,6 +594,19 @@ end
         @test length(EvoTrees.importance(m; feature_names=[:a, :a, :b, :c])) == 4
     end
 
+    @testset "predict with mismatched column count" begin
+        rng = Xoshiro(5)
+        x = rand(rng, 300, 4)
+        y = x[:, 1] .+ 2 .* x[:, 4]
+        m = fit(EvoTreeRegressor(nrounds=10, max_depth=4); x_train=x, y_train=y)
+
+        @test EvoTrees.predict(m, x) == EvoTrees.predict(m, x)
+        for k in (1, 2, 3)
+            @test_throws ErrorException EvoTrees.predict(m, x[:, 1:k])
+        end
+        @test_throws ErrorException EvoTrees.predict(m, hcat(x, rand(rng, 300, 2)))
+    end
+
     @testset "gamma target support" begin
         rng = Xoshiro(21)
         x = rand(rng, 200, 3)


### PR DESCRIPTION
`binarize(X::AbstractMatrix; feature_names, edges)` takes `feature_names` and never looks at it. It sizes `x_bin` from the data with `zeros(UInt8, size(X))` and loops over `axes(X, 2)`, so a matrix with fewer columns than the model was trained on yields an `x_bin` that is too narrow. The tree descent then reads `x_bin[i, feat]` under `@inbounds` (`src/predict.jl:6`), so a feature index past the end is an unchecked read instead of a `BoundsError`.

A model trained on 4 features scores a 1 column matrix without complaint, and the results are not reproducible between runs, which is what you would expect from reading past the end of the array. Same script, same seed, two consecutive runs on main:

```julia
using EvoTrees, Random, Statistics
rng = Xoshiro(5)
x = rand(rng, 500, 4)
y = x[:, 1] .+ 2 .* x[:, 4]
m = EvoTrees.fit(EvoTreeRegressor(nrounds=20, max_depth=4); x_train=x, y_train=y)

for k in (4, 3, 2, 1)
    println("  $k cols -> mean ", mean(EvoTrees.predict(m, x[:, 1:k])))
end
```

```
run 1                       run 2
  4 cols -> mean 1.5522379    4 cols -> mean 1.5522379
  3 cols -> mean 1.7793286    3 cols -> mean 1.5480727
  2 cols -> mean 1.7540964    2 cols -> mean 1.147212
  1 cols -> mean 1.5915703    1 cols -> mean 1.1866128
```

Only the correct 4 column call is stable. Passing more columns than the model expects does already fail, but as a `CompositeException` out of `edges[j]` inside the threaded loop rather than as something a user can act on.

This checks the column count against `feature_names` at the top of the matrix method, which covers both directions and reads like the other input validation added in #363 and #369. The table method is unaffected since it selects its columns by name.

Tests sit in `test/core.jl` beside the other validation checks: a full width matrix still predicts, 1, 2 and 3 columns throw, and a too wide matrix throws. Reverting the source change fails 4 of the 5. Full suite is green at 661 of 661.
