### PR TITLE
Encode categorical features against the model's training levels at predict

### DIFF
--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -79,7 +79,15 @@ function binarize(df; feature_names, edges)
         if eltype(col) <: Bool
             x_bin[:, j] .= col .+ 1
         elseif eltype(col) <: CategoricalValue
-            x_bin[:, j] .= levelcode.(col)
+            col_levels = levels(col)
+            pos = indexin(col_levels, edges[j])
+            k = findfirst(isnothing, pos)
+            isnothing(k) || error(
+                "Feature $(feature_names[j]) has level $(repr(string(col_levels[k]))) that was " *
+                "not present in the training data. Training levels: $(string.(edges[j]))."
+            )
+            lookup = UInt8[pos[i] for i in eachindex(pos)]
+            x_bin[:, j] .= getindex.(Ref(lookup), levelcode.(col))
         elseif eltype(col) <: Real
             x_bin[:, j] .= searchsortedfirst.(Ref(edges[j]), col)
         else

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -163,3 +163,36 @@ end
     @test mse_gain_pct < -0.75
 
 end
+
+@testset "Tables - categorical level encoding at predict" begin
+
+    seed!(7)
+    n = 900
+    vals = rand(["a", "b", "c"], n)
+    truth = Dict("a" => 10.0, "b" => 0.0, "c" => -10.0)
+    dtrain = DataFrame(num=randn(n),
+                       cat=categorical(vals, levels=["a", "b", "c"]),
+                       y=[truth[v] for v in vals])
+
+    model = fit(EvoTreeRegressor(nrounds=40, max_depth=3, eta=0.3), dtrain;
+                target_name="y", feature_names=[:num, :cat])
+
+    ref = EvoTrees.predict(model, DataFrame(num=zeros(3),
+                                            cat=categorical(["a", "b", "c"], levels=["a", "b", "c"])))
+    @test ref[1] > 5 && abs(ref[2]) < 1 && ref[3] < -5
+
+    sub = EvoTrees.predict(model, DataFrame(num=zeros(2), cat=categorical(["b", "c"])))
+    @test sub ≈ ref[2:3]
+
+    rev = EvoTrees.predict(model, DataFrame(num=zeros(3),
+                                            cat=categorical(["a", "b", "c"], levels=["c", "b", "a"])))
+    @test rev ≈ ref
+
+    for (i, v) in enumerate(["a", "b", "c"])
+        one_row = EvoTrees.predict(model, DataFrame(num=[0.0], cat=categorical([v])))
+        @test one_row[1] ≈ ref[i]
+    end
+
+    @test_throws Exception EvoTrees.predict(
+        model, DataFrame(num=zeros(2), cat=categorical(["a", "zzz"])))
+end


### PR DESCRIPTION
Closes #368.

The categorical branch of `binarize` bins with `levelcode.(col)`, which is an index into the pool of the array being scored, not into the levels the model was trained on. `get_edges` stores the training levels in `edges[j]`, and every other branch of `binarize` uses `edges[j]`, so the categorical one was the only place the stored edges were ignored. Any scoring batch carrying a different pool got silently wrong predictions.

The sharpest case is scoring a row at a time, since a one element categorical has a one level pool and every value binned as the first training level. On main:

```
cat = a   truth = 10.0   predict = 9.999993
cat = b   truth = 0.0    predict = 9.999993
cat = c   truth = -10.0  predict = 9.999993
```

This maps the column's levels through `edges[j]` once and then indexes that lookup with `levelcode`, rather than doing a per observation `indexin`, so the hot path stays a plain array index and does not gain a hash lookup per row. A level that was not present in training now throws instead of being scored as some other level.

Training is unaffected, which is the part I most wanted to be sure of: at fit time `levels(col)` is exactly `edges[j]`, so the lookup is the identity. Fitting a model with one unordered and one ordered categorical feature and summing the predictions gives the same checksum of -17.37777761858888 before and after the change.

Tests go in `test/tables.jl` next to the other categorical cases: a batch missing a level, a batch with the levels declared in reverse order, and single row scoring all have to agree with the full pool result, and an unseen level has to throw. Reverting the source change fails 5 of the 7. Full suite is green at 663 of 663.

One thing worth flagging: the unseen level `error` is raised inside the existing `@threads` loop, so it surfaces as a `CompositeException` wrapping the message rather than a bare `ErrorException`. That matches the `Invalid feature eltype` error already in that loop, so I left it, but say the word if you would rather the check was hoisted out of the loop to give a cleaner error.
