### PR TITLE
Accumulate every tree of a round in the eval callback

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -159,8 +159,13 @@ function (cb::CallBack)(logger, iter)
     return nothing
 end
 
-function (cb::CallBack)(logger, iter, tree)
-    predict!(cb.p, tree, cb.x_bin, cb.feattypes)
+# `trees` is every tree added by the round being logged. With `bagging_size > 1` a round adds
+# that many, each scaled by `1 / bagging_size`, so accumulating only one leaves the eval
+# prediction at a fraction of the model the round actually produced.
+function (cb::CallBack)(logger, iter, trees)
+    for tree in trees
+        predict!(cb.p, tree, cb.x_bin, cb.feattypes)
+    end
     return cb(logger, iter)
 end
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -265,6 +265,9 @@ function grow_otree!(
 end
 
 # A no-op on the CPU, but on the GPU we perform garbage collection
+# The trees appended by the round just grown. `grow_evotree!` pushes `bagging_size` of them.
+_round_trees(m, n) = view(m.trees, (lastindex(m.trees)-n+1):lastindex(m.trees))
+
 post_fit_gc(::Type{<:CPU}) = nothing
 
 """
@@ -338,7 +341,7 @@ function fit(
     for i = 1:params.nrounds
         grow_evotree!(m, cache, params)
         if !isnothing(logger)
-            cb(logger, i, m.trees[end])
+            cb(logger, i, _round_trees(m, params.bagging_size))
             if i % print_every_n == 0 && verbosity > 0
                 @info "iter $i" metric = logger[:metrics][end]
             end
@@ -436,7 +439,7 @@ function fit(
     for i = 1:params.nrounds
         grow_evotree!(m, cache, params)
         if !isnothing(logger)
-            cb(logger, i, m.trees[end])
+            cb(logger, i, _round_trees(m, params.bagging_size))
             if i % print_every_n == 0 && verbosity > 0
                 @info "iter $i" metric = logger[:metrics][end]
             end

--- a/test/core.jl
+++ b/test/core.jl
@@ -492,6 +492,18 @@ end
         @test length(m.trees) == 20
         @test all(isfinite, predict(m, x))
 
+        # A round adds `bagging_size` trees, each scaled by `1 / bagging_size`, so the eval
+        # callback has to accumulate all of them. Accumulating one leaves the logged metric
+        # describing a fraction of the model, and early stopping then selects on it.
+        for bs in (1, 2, 5)
+            m = fit(EvoTreeRegressor(nrounds=12, max_depth=4, eta=0.3, bagging_size=bs,
+                    metric=:mse, rowsample=0.8);
+                x_train=x, y_train=y, x_eval=x, y_eval=y, verbosity=0)
+            logged = m.info[:logger][:metrics][end]
+            actual = mean((vec(predict(m, x)) .- y) .^ 2)
+            @test logged ≈ actual rtol = 1e-5
+        end
+
         # Mutating a fitted config is the path MLJ tuning takes, so the second `check_args`
         # method must reject the same values.
         config = EvoTreeRegressor(nrounds=5)


### PR DESCRIPTION
With `bagging_size > 1` the logged eval metric describes a fraction of the model being trained, and early stopping selects on it.

`grow_evotree!` adds `bagging_size` trees per round, each with leaf values scaled by `1 / bagging_size` so the bag sums to one boosting step. The callback was handed one of them, `cb(logger, i, m.trees[end])`, and `CallBack` accumulates its eval prediction incrementally, so `cb.p` received one tree in every `bagging_size`. Training's own `cache.pred` is updated inside the bagging loop, so the model is unaffected; only the eval path drifts.

Logged metric against the MSE of `predict` on the same eval data, before and after:

```
bagging_size   logged/actual before   after
     1                1.000           1.000
     2                1.808           1.000
     5                2.850           1.000
```

The `bagging_size=1` column agreeing to five decimals is the contract the logger already honours. `best_metric` and `best_iter` move with it: at `bagging_size=5` the selected iteration goes from 15 to 10 once the curve is right.

The callback now accumulates every tree it is handed and the call sites pass the round's trees. `bagging_size` is documented, validated, and used at 16 in `docs/juliacon/assets`.

Tests cover the three bagging sizes against `predict`. Two of the three fail on current main.
