### PR TITLE
Reject negative targets for Tweedie and Poisson

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -66,6 +66,18 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
                 "Gamma regression requires a strictly positive target, got a minimum of $ymin. " *
                 "The gamma deviance is undefined at 0."
             )
+        elseif L == Tweedie
+            ymin = minimum(y_train)
+            ymin < 0 && error(
+                "Tweedie regression requires a non-negative target, got a minimum of $ymin. " *
+                "The tweedie deviance is undefined below 0."
+            )
+        elseif L == Poisson
+            ymin = minimum(y_train)
+            ymin < 0 && error(
+                "Poisson regression requires a non-negative target, got a minimum of $ymin. " *
+                "The poisson deviance is undefined below 0."
+            )
         end
         if y_train isa AbstractVector
             K = 1

--- a/test/core.jl
+++ b/test/core.jl
@@ -469,6 +469,25 @@ end
         @test check_args(config) === nothing
     end
 
+    @testset "target domain for positive losses" begin
+        # Tweedie went to NaN on every prediction from a single negative target, and Poisson
+        # fit a corrupted model, while only Gamma was checked. Zero is inside Tweedie's and
+        # Poisson's domains and outside Gamma's.
+        xd = rand(200, 3)
+        yd = 2 .* xd[:, 1] .+ 1
+        neg = copy(yd); neg[1] = -1.0
+        zer = copy(yd); zer[1] = 0.0
+        for loss in (:tweedie, :poisson, :gamma)
+            @test_throws ErrorException fit(EvoTreeRegressor(loss=loss, nrounds=2); x_train=xd, y_train=neg, verbosity=0)
+        end
+        for loss in (:tweedie, :poisson)
+            @test fit(EvoTreeRegressor(loss=loss, nrounds=2); x_train=xd, y_train=zer, verbosity=0) isa EvoTrees.EvoTree
+        end
+        @test_throws ErrorException fit(EvoTreeRegressor(loss=:gamma, nrounds=2); x_train=xd, y_train=zer, verbosity=0)
+        # a valid target still trains
+        @test all(isfinite, predict(fit(EvoTreeRegressor(loss=:tweedie, nrounds=5); x_train=xd, y_train=yd, verbosity=0), xd))
+    end
+
     @testset "check_args L2 and bagging_size" begin
         # Both used to be accepted unvalidated. A negative `L2` lands in the leaf denominator
         # and takes every prediction to NaN; a `bagging_size` below 1 makes the per-round loop


### PR DESCRIPTION
A single negative value in the target takes `loss=:tweedie` to `NaN` on every prediction, with no error. `loss=:poisson` fits a corrupted model on the same input. Only `:gamma` is checked.

`src/init.jl` validates the target for `Gamma` alone inside the branch shared by all three positive-domain losses. The Tweedie gradient carries `pred^-0.5` terms weighted by `y`, so a negative target drives the aggregated leaf Hessian negative, the `max(ϵ, ...)` clamp in `pred_leaf_cpu!` turns that denominator into `eps()`, and the leaf explodes into `NaN` that propagates through every later round. Poisson's gradient stays finite but the deviance it minimises is undefined below zero: one negative row out of 400 moves the prediction floor from 29.7 to 6.1.

400 rows, negatives set to -100:

```
                   before                              after
negatives   tweedie      poisson         tweedie / poisson
   0        ok           ok              ok
   1        NaN 400/400  floor 29.7->6.1 error, non-negative target required
   5        NaN 400/400  floor 29.7->4.7 error
```

The guard is extended to both, requiring a non-negative target. Zero stays valid for Tweedie and Poisson, since mass at zero is the point of Tweedie and counts start there, and stays invalid for Gamma.

Tests cover all three losses with a negative target, zero for each, and a valid fit. The Gamma guard had no test before.
