### PR TITLE
Score each target against its own location in the grouped corr metric

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -167,7 +167,7 @@ function _ndcg_chunk!(scores, weights, p, y, w, group, chunk, ndcg_k::Int)
     return nothing
 end
 
-function _corr_chunk!(scores, weights, p, y, w, group, chunk, K::Int)
+function _corr_chunk!(scores, weights, p, y, w, group, chunk, K::Int, stride::Int)
     pred = Float64[]
     obs = Float64[]
     wt = Float64[]
@@ -178,7 +178,7 @@ function _corr_chunk!(scores, weights, p, y, w, group, chunk, K::Int)
         acc = 0.0
         scored = 0
         for k in 1:K
-            s = _corr_group!(pred, obs, wt, p, y, w, rows, k)
+            s = _corr_group!(pred, obs, wt, p, y, w, rows, k, stride * (k - 1) + 1)
             isnothing(s) && continue
             acc += s
             scored += 1
@@ -266,7 +266,7 @@ end
 # twice. The accumulator is Float64 regardless of `T`, because the centring cancels
 # catastrophically in Float32 once predictions sit far from zero.
 function _corr_group!(pred::Vector{Float64}, obs::Vector{Float64}, wt::Vector{Float64},
-    p::AbstractMatrix, y, w::AbstractVector, rows, k::Int)
+    p::AbstractMatrix, y, w::AbstractVector, rows, k::Int, prow::Int=k)
     n = length(rows)
     n < 2 && return nothing
     resize!(pred, n)
@@ -275,7 +275,7 @@ function _corr_group!(pred::Vector{Float64}, obs::Vector{Float64}, wt::Vector{Fl
     # the gather is scattered and cannot vectorise, so it is kept apart from the arithmetic,
     # which then runs over contiguous scratch
     @inbounds for (i, r) in enumerate(rows)
-        pred[i] = p[k, r]
+        pred[i] = p[prow, r]
         obs[i] = _target(y, k, r)
         wt[i] = w[r]
     end
@@ -336,13 +336,16 @@ function corr(
         "when fitting from a table, or `group_eval` alongside `x_eval` when fitting from a matrix."
     )
     # Number of targets, not of prediction rows: an MLE model carries its scale in row 2,
-    # which is not something to correlate against the target.
+    # which is not something to correlate against the target. Such a model interleaves the two
+    # per target, so target `k` predicts into row `2k - 1`. The layout is read off the matrix
+    # rather than the loss, to keep the metric free of loss specific arguments.
     K = y isa AbstractMatrix ? size(y, 1) : 1
+    stride = size(p, 1) == 2K ? 2 : 1
     ng = ngroups(group)
     scores = zeros(Float64, ng)
     weights = zeros(Float64, ng)
     @threads for chunk in _group_chunks(ng)
-        _corr_chunk!(scores, weights, p, y, w, group, chunk, K)
+        _corr_chunk!(scores, weights, p, y, w, group, chunk, K, stride)
     end
     sw = sum(weights)
     sw <= 0 && return zero(Float64)

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -396,6 +396,17 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
             group=build_group_index(q2))
         @test got2 ≈ 1.0 rtol = 1e-6
 
+        # A two-parameter likelihood interleaves location and scale per target, so target 2
+        # predicts into row 3, not row 2. Row 2 here is anti-correlated with target 2 inside
+        # every group, so reading it would score 0.0 rather than 1.0.
+        qm = UInt32[1, 1, 1, 2, 2, 2]
+        ym = Float32[1 2 3 4 5 6; 6 5 4 3 2 1]
+        pm = Float32[1 2 3 4 5 6; 1 2 3 1 2 3; 6 5 4 3 2 1; 0 0 0 0 0 0]
+        @test corr(pm, ym, ones(Float32, 6), Float32[]; group=build_group_index(qm)) ≈ 1.0 rtol = 1e-6
+        # a single-target MLE model is the K == 1 case of the same rule
+        @test corr(Float32[1 2 3 4 5 6; 9 9 9 9 9 9], Float32[1, 2, 3, 4, 5, 6],
+            ones(Float32, 6), Float32[]; group=build_group_index(qm)) ≈ 1.0 rtol = 1e-6
+
         @test EvoTrees.is_maximise(corr)
         @test_throws ErrorException corr(reshape(Float32.(pv), 1, :), Float32.(yv),
             ones(Float32, 12), Float32[])
@@ -416,6 +427,15 @@ using EvoTrees: fit, predict, build_group_index, ngroups, group_rows, subsample,
             @test all(-1 .<= mets .<= 1)
             @test mets[end] > 0.5
         end
+
+        # the same, with two targets: the second must be scored against its own location
+        y2 = -3 .* x[:, 2] .+ 0.3 .* randn(rng, nobs)
+        dtr2 = (q=g[tr], f1=x[tr, 1], f2=x[tr, 2], f3=x[tr, 3], y=y[tr], y2=y2[tr])
+        dev2 = (q=g[te], f1=x[te, 1], f2=x[te, 2], f3=x[te, 3], y=y[te], y2=y2[te])
+        mmt = fit(EvoTreeMLE(loss=:gaussian_mle, metric=:corr, nrounds=20, max_depth=4), dtr2;
+            target_name=["y", "y2"], eval_group_name=:q, deval=dev2, verbosity=0)
+        @test size(predict(mmt, dev2), 2) == 4
+        @test mmt.info[:logger][:metrics][end] > 0.8
     end
 
 end


### PR DESCRIPTION
The grouped `corr` metric reads prediction row `k` for target `k`, but a two parameter likelihood interleaves location and scale, so target `k` predicts into row `2k - 1`. With two targets the second one is therefore correlated against the first target's unconstrained scale rather than against its own location.

On 20k rows in groups of 64, `EvoTreeMLE(loss=:gaussian_mle, metric=:corr)` with two targets:

```
metric as logged                            0.4595
same computation over the location rows     0.9885
target 2 against row 2, target 1 log scale -0.0660
target 2 against row 3, target 2 location   0.9925
```

Fixing my own oversight from #375. A single target is unaffected, which is why it went unnoticed: `K` is 1 there and row 1 is the location either way, so the existing coverage passed.

The layout is read off the prediction matrix rather than passed in with the loss, so the metric keeps the loss agnostic interface you asked for on #327.

Worth flagging that `benchmarks/regressor-grps.jl` sets `n_targets = 2` with `gaussian_mle` and `corr`, so the committed grouped results were tracking this.

Tests cover the interleaved layout directly and a two target fit. Both fail on current main.
