### PR TITLE
Load models saved before the intercept moved out of the first tree

### DIFF
--- a/src/EvoTrees.jl
+++ b/src/EvoTrees.jl
@@ -47,13 +47,60 @@ include("shap.jl")
 using .Shap
 include("plot.jl")
 
-function save(model::EvoTree, path)
-    BSON.bson(path, Dict(:model => model))
+"""
+    EvoTreeLegacyPreV20{L,K}
+
+The `EvoTree` layout used before v0.20 moved the intercept out of `trees[1]` into `bias`. It exists
+only so `load` can read a model saved by an earlier version; nothing else should reach for it.
+"""
+struct EvoTreeLegacyPreV20{L,K}
+    loss_type::Type{L}
+    K::UInt8
+    trees::Vector{Tree{L,K}}
+    info::Dict{Symbol,Any}
 end
 
+function save(model::EvoTree{L,K}, path) where {L,K}
+    # stamped so a later layout change has something to branch on rather than guessing from shape
+    info = copy(model.info)
+    info[:save_version] = string(pkgversion(@__MODULE__))
+    stamped = EvoTree{L,K}(model.loss_type, model.K, model.bias, model.trees, info)
+    BSON.bson(path, Dict(:model => stamped))
+end
+
+"""
+    load(path)
+
+Read a model written by [`save`](@ref), including one written before v0.20.
+
+BSON rebuilds a struct by field position, so a model from an earlier version puts its `trees` into
+the `bias` field and fails to load. Nothing in the file records which layout it is, so it is read
+off the document: four stored fields is the old one, whose first tree is a single leaf carrying the
+intercept. `save` now records a version, which removes the guesswork for the next change.
+"""
 function load(path)
-    m = BSON.load(path, @__MODULE__)
-    return m[:model]
+    doc = BSON.parse(path)
+    entry = get(doc, :model, nothing)
+    if _is_pre_v20(entry)
+        entry[:type][:name] = Any["EvoTrees", "EvoTreeLegacyPreV20"]
+        return _upgrade(BSON.raise_recursive(doc, @__MODULE__)[:model])
+    end
+    return BSON.load(path, @__MODULE__)[:model]
+end
+
+_is_pre_v20(entry) =
+    entry isa AbstractDict &&
+    haskey(entry, :data) && length(entry[:data]) == 4 &&
+    haskey(entry, :type) && entry[:type][:name] == Any["EvoTrees", "EvoTree"]
+
+function _upgrade(m::EvoTreeLegacyPreV20{L,K}) where {L,K}
+    isempty(m.trees) && error("This model was saved before v0.20 and carries no trees, so its " *
+                              "intercept cannot be recovered.")
+    # the first tree was the intercept: a single leaf, no splits
+    bias = vec(copy(m.trees[1].pred))
+    info = copy(m.info)
+    info[:save_version] = get(info, :save_version, "pre-0.20")
+    return EvoTree{L,K}(L, m.K, bias, m.trees[2:end], info)
 end
 
 end # module

--- a/test/core.jl
+++ b/test/core.jl
@@ -711,4 +711,41 @@ end
     @test loaded.bias == m.bias
     @test length(loaded.trees) == length(m.trees)
     @test predict(loaded, x) == predict(m, x)
+@testset "save and load" begin
+    x = rand(Xoshiro(1), 500, 4)
+    y = x[:, 1] .+ rand(Xoshiro(2), 500)
+    m = fit(EvoTreeRegressor(nrounds=10, max_depth=3, seed=1); x_train=x, y_train=y, verbosity=0)
+    path = joinpath(mktempdir(), "m.bson")
+    EvoTrees.save(m, path)
+    back = EvoTrees.load(path)
+    @test predict(back, x) == predict(m, x)
+    @test back.bias == m.bias
+    @test length(back.trees) == length(m.trees)
+    # what `save` writes now carries the version, so a later layout change has a key to read
+    @test haskey(back.info, :save_version)
+
+    # Before v0.20 the intercept was a leading single-leaf tree and there was no `bias` field.
+    # BSON rebuilds a struct by position, so such a model puts its trees into `bias` and fails to
+    # load. The shape test and the upgrade are exercised directly rather than through a binary
+    # fixture; the whole path was checked against a file written by the registered v0.19.0.
+    lead = EvoTrees.Tree{EvoTrees.MSE,1}(zeros(Int, 1), zeros(UInt8, 1), zeros(Float32, 1),
+        zeros(Float32, 1), reshape(copy(m.bias), :, 1), zeros(Bool, 1))
+    legacy = EvoTrees.EvoTreeLegacyPreV20{EvoTrees.MSE,1}(
+        EvoTrees.MSE, m.K, vcat([lead], m.trees), copy(m.info))
+    upgraded = EvoTrees._upgrade(legacy)
+    @test upgraded isa EvoTrees.EvoTree
+    @test upgraded.bias == m.bias
+    @test length(upgraded.trees) == length(m.trees)
+    @test predict(upgraded, x) == predict(m, x)
+
+    # the old layout is recognised by its field count and type name, the new one is not
+    typedoc = Dict(:tag => "datatype", :name => Any["EvoTrees", "EvoTree"], :params => Any[])
+    @test EvoTrees._is_pre_v20(Dict(:tag => "struct", :type => typedoc, :data => Any[1, 2, 3, 4]))
+    @test !EvoTrees._is_pre_v20(Dict(:tag => "struct", :type => typedoc, :data => Any[1, 2, 3, 4, 5]))
+    @test !EvoTrees._is_pre_v20(Dict(:tag => "struct",
+        :type => Dict(:tag => "datatype", :name => Any["Other", "Thing"], :params => Any[]),
+        :data => Any[1, 2, 3, 4]))
+    @test !EvoTrees._is_pre_v20(nothing)
+end
+
 end


### PR DESCRIPTION
A model saved by the registered v0.19.0 cannot be loaded on `main`.

#384 moved the intercept out of `trees[1]` into `bias::Vector{Float32}`, and `load` is a plain `BSON.load`, which rebuilds a struct by field position, so the old `trees` vector lands in `bias`:

```
julia> EvoTrees.load("m019.bson")
ERROR: MethodError: Cannot `convert` an object of type EvoTrees.Tree{EvoTrees.MSE, 1}
       to an object of type Float32
```

Every model from a released version fails this way. Nothing in the file records the layout, so `load` reads it off the shape: four stored fields is the pre-v0.20 one, where the first tree is a single leaf holding the intercept. That leaf becomes `bias` and the rest carry over. On a file written by v0.19.0, 21 trees become a bias of 1.0108427 and 20 trees, with the same predictions as before, checksum 2021.6824 both ways.

`save` now writes `info[:save_version]` so the next layout change has something to branch on.

Tests cover the round trip, the version stamp, the upgrade, and the shape check against the old layout, the current one, a foreign type and a missing entry. I did not commit the v0.19.0 file as a fixture since it is binary, but I can add it.
