### PR TITLE
Keep the quantile edge when a feature has a single bin edge

### DIFF
--- a/src/fit-utils.jl
+++ b/src/fit-utils.jl
@@ -14,9 +14,6 @@ function get_edges(X::AbstractMatrix{T}; nbins, rng=Random.MersenneTwister(), kw
     feattypes = Vector{Bool}(undef, nfeats)
     @threads for j in 1:size(X, 2)
         edges[j] = quantile(view(X, idx, j), (1:(nbins-1)) / nbins)
-        if length(edges[j]) == 1
-            edges[j] = [minimum(view(X, idx, j))]
-        end
         featbins[j] = length(edges[j]) + 1
         feattypes[j] = true
     end
@@ -49,9 +46,6 @@ function get_edges(df; feature_names, nbins, rng=Random.MersenneTwister(), kwarg
             feattypes[j] = true
         else
             error("Invalid feature eltype: $(feature_names[j]) is $(eltype(col))")
-        end
-        if length(edges[j]) == 1
-            edges[j] = [minimum(col)]
         end
     end
     return edges, featbins, feattypes

--- a/test/core.jl
+++ b/test/core.jl
@@ -712,3 +712,20 @@ end
     @test length(loaded.trees) == length(m.trees)
     @test predict(loaded, x) == predict(m, x)
 end
+
+@testset "nbins=2 single edge" begin
+    seed!(11)
+    x = reshape(rand(2_000), :, 1)
+    y = Float64.(x[:, 1] .> 0.5)
+
+    edges, featbins, _ = EvoTrees.get_edges(x; nbins=2)
+    @test only(edges[1]) ≈ median(x[:, 1])
+    @test featbins == UInt8[2]
+
+    tedges, tfeatbins, _ = EvoTrees.get_edges((x1=x[:, 1],); feature_names=[:x1], nbins=2)
+    @test only(tedges[1]) ≈ median(x[:, 1])
+    @test tfeatbins == UInt8[2]
+
+    m = fit(EvoTreeRegressor(nrounds=30, max_depth=2, eta=0.3, nbins=2); x_train=x, y_train=y)
+    @test sqrt(mean((predict(m, x) .- y) .^ 2)) < 0.1
+end


### PR DESCRIPTION
Closes #377.

`get_edges` computes `quantile(col, (1:(nbins-1)) / nbins)` and then replaces the result with `[minimum(col)]` whenever it came out one element long. For `nbins=2` that single element is the median, which is the correct and only edge, so the overwrite throws it away and the feature can only ever split off its smallest observation.

I asked in the issue what the fallback was guarding and went and looked. It goes back to ae2ddb2 in 2019, where the edges were

```julia
edges[i] = unique(quantile(view(X, :, i), (0:nbins) / nbins))[2:(end-1)]
if length(edges[i]) == 0
    edges[i] = [minimum(view(X, :, i))]
end
```

Stripping the first and last quantile there really can leave nothing, so the fallback was supplying an edge to a feature that had none. 8e8a8dd in 2023 changed the range to `(1:nbins-1) / nbins`, which cannot come out empty for `nbins >= 2`, and changed the condition from `== 0` to `== 1` at the same time. That turned "give a feature with no edges one" into "throw away the only edge a feature has". Removing it puts the quantile back.

In the matrix method there is no `unique`, so a one element result means `nbins=2` and nothing else. In the table method `unique` can also collapse the interior quantiles of a heavily tied column to a single value, so it is not only an `nbins=2` bug there. A column with 70 percent of its rows at 0.5 collapses to the single edge 0.5 at `nbins=3`, and main replaces that with the minimum 0.00073: the feature then makes no split at all and the fit sits at the mean, rmse 0.357071. Keeping the quantile edge splits at 0.5 and reaches 8.0e-6.

On the issue's example the edge moves from 0.00016, the column minimum, to 0.49774, the median, and rmse goes from 0.499996 to 0.044632. Same numbers for the matrix and the table constructor.

The case I wanted to be sure about is a column where the surviving quantile is the column maximum, since there the quantile edge puts every observation in bin 1 and the minimum at least separates something. Built one with 60 percent of the rows at the maximum: before and after the change the fit makes 0 splits and rmse is 0.407664 either way, because the fallback's split isolates the single minimum row and `min_weight` rejects it. So it was not buying anything there. A constant column is unchanged, its quantile is its minimum. A single level categorical is unchanged, `minimum(col)` is that level. A default `nbins` regression is untouched, prediction checksum -168.54834 before and after. The KernelAbstractions init calls the same `get_edges`, so the GPU path picks this up too.

Tests go in `test/core.jl`: the single edge is the median for both `get_edges` methods, `featbins` is still 2, and an `nbins=2` fit of a median split target has to reach an rmse under 0.1. Reverting the source change fails 3 of the 5. Full suite is green at 1062 of 1062.
