### PR TITLE
Check the offset shape against the number of fitted parameters

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -92,6 +92,7 @@ function CallBack(
 
     offset = !isnothing(offset_name) ? T.(Tables.getcolumn(deval, _offset_name)) : nothing
     if !isnothing(offset)
+        check_offset(offset, nobs, K)
         L == LogLoss && (offset .= logit.(offset))
         L in [Poisson, Gamma, Tweedie] && (offset .= log.(offset))
         L == MLogLoss && (offset .= log.(offset))
@@ -142,6 +143,7 @@ function CallBack(
 
     offset = !isnothing(offset_eval) ? T.(offset_eval) : nothing
     if !isnothing(offset)
+        check_offset(offset, nobs, K)
         L == LogLoss && (offset .= logit.(offset))
         L in [Poisson, Gamma, Tweedie] && (offset .= log.(offset))
         L == MLogLoss && (offset .= log.(offset))

--- a/src/init.jl
+++ b/src/init.jl
@@ -197,7 +197,20 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
         end
     end
     μ = T.(μ)
+    !isnothing(offset) && check_offset(offset, size(y, ndims(y)), K)
     return K, y, μ, target_levels, target_isordered
+end
+
+function check_offset(offset, nobs, K)
+    size(offset, 1) == nobs || error(
+        "`offset` has $(size(offset, 1)) rows but there are $(nobs) observations. " *
+        "Each row needs exactly one offset."
+    )
+    size(offset, 2) == K || error(
+        "`offset` has $(size(offset, 2)) column(s) but the loss fits $(K) parameter(s) per " *
+        "observation. Pass one offset column per fitted parameter."
+    )
+    return nothing
 end
 
 function init_core(params::EvoTypes, ::Type{CPU}, data, feature_names, y_train, w, offset, group=nothing)

--- a/test/core.jl
+++ b/test/core.jl
@@ -569,6 +569,36 @@ end
         @test isfinite(mw.info[:logger][:metrics][end])
     end
 
+    @testset "offset shape" begin
+        rng = Xoshiro(17)
+        x = rand(rng, 200, 3)
+        y = 2 .* x[:, 1] .+ 0.2 .* randn(rng, 200)
+        off1 = 2 .* x[:, 1]
+        off2 = hcat(off1, ones(200))
+
+        @test_throws ErrorException fit(
+            EvoTreeGaussian(nrounds=3); x_train=x, y_train=y, offset_train=copy(off1), verbosity=0)
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(nrounds=3); x_train=x, y_train=hcat(y, y),
+            offset_train=copy(off1), verbosity=0)
+        @test_throws ErrorException fit(
+            EvoTreeRegressor(nrounds=3); x_train=x, y_train=y,
+            offset_train=copy(off1)[1:100], verbosity=0)
+        @test_throws ErrorException fit(
+            EvoTreeGaussian(nrounds=3, metric=:gaussian_mle); x_train=x, y_train=y,
+            offset_train=copy(off2), x_eval=x, y_eval=y, offset_eval=copy(off1), verbosity=0)
+
+        m = fit(
+            EvoTreeGaussian(nrounds=3, metric=:gaussian_mle); x_train=x, y_train=y,
+            offset_train=copy(off2), x_eval=x, y_eval=y, offset_eval=copy(off2), verbosity=0)
+        @test isfinite(m.info[:logger][:metrics][end])
+
+        m1 = fit(
+            EvoTreeRegressor(nrounds=3); x_train=x, y_train=y, offset_train=copy(off1),
+            verbosity=0)
+        @test all(isfinite, predict(m1, x))
+    end
+
     @testset "classifier target levels" begin
         rng = Xoshiro(7)
         x = rand(rng, 40, 3)


### PR DESCRIPTION
Closes #374.

An offset is applied as `pred .+= offset'`, where `pred` is `(K, nobs)`, and nothing checks the offset's shape against `K`. `offset_name` reads a single table column, so for every loss with `K > 1` that one column is broadcast across all `K` parameters.

What that does today, per loss:

- `EvoTreeGaussian` and `EvoTreeMLE`: the mean offset lands in the unconstrained scale row as well. `unconstrain_mle_scale!` indexes `offset[:, 2:2:end]`, which on a vector is the empty range `2:2:1`, so the scale is not link transformed either. On the issue's example the fit now returns `sigma = Inf` and an eval metric of `-Inf`. It was a degraded metric of -0.8142 against -0.4636 when I opened the issue in August, so the v20 changes have made it worse.
- Multi-target regression: no error at all, the same offset column is applied to every target.
- `EvoTreeClassifier`: the offset value itself is cancelled, because the same number goes onto every class logit and softmax is shift invariant. A constant offset column and a random one give bit identical predictions. But supplying an offset at all also sets the bias to zero, so the class prior initialisation is thrown away and nothing takes its place. On a 3 class problem with counts 219/897/84 the bias goes from `[-1.41, 0.0, -2.37]` to `[0, 0, 0]` and predictions move by up to 0.20 against the same fit with no offset.
- An offset with the wrong number of rows: a `DimensionMismatch` out of the broadcast.

`check_offset` goes at the end of `_init_target`, which is where the gamma and tweedie target checks already sit, so the CPU and KernelAbstractions init paths both pick it up from one place. The eval offset is built separately in the two `CallBack` constructors, so it gets the same call there.

The shape the code already wants keeps working. Passing the same mean offset as an `(nobs, 2)` matrix through `offset_train`, scale column at 1.0, gives an eval metric of -0.4139 against -0.4323 for the no-offset fit, so it beats the baseline as an offset should.

This does mean `offset_name` cannot be used with any `K > 1` loss, since a table column is one column. That is the state the issue asked about and I have not changed it here. Letting `offset_name` take a vector of column names the way `target_name` does is the other half of the question and is still open.

Tests in `test/core.jl` next to the other input validation: a 1-D offset for Gaussian, for multi-target and a short offset all have to throw, an eval offset that does not match the train offset has to throw, and a 2 column Gaussian offset and a 1-D regressor offset both have to keep fitting. 4 of the 6 fail on main. The multi-target case is the one that does not error there at all, and the short offset throws `DimensionMismatch` rather than an `ErrorException`. Full suite is green at 1063 of 1063. I have no GPU here, so the KernelAbstractions path is covered by sharing `_init_target` rather than by a run.
