### PR TITLE
Reject a non-finite target instead of returning an all-NaN model

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -44,6 +44,14 @@ function _init_target(::Type{L}, y_train, params, offset, ::Type{T}) where {L,T}
               "(gaussian_mle, logistic_mle), and credibility losses (cred_var, cred_std). " *
               "Got loss $(params.loss).")
     end
+    if eltype(y_train) <: Real
+        i = findfirst(!isfinite, y_train)
+        isnothing(i) || error(
+            "Target must be finite, got $(y_train[i]) at index $i. A non-finite target " *
+            "propagates through the initial bias into every gradient and leaf, leaving a " *
+            "model that predicts NaN everywhere."
+        )
+    end
     target_levels = nothing
     target_isordered = false
     if L == LogLoss

--- a/test/core.jl
+++ b/test/core.jl
@@ -488,6 +488,25 @@ end
         @test all(isfinite, predict(fit(EvoTreeRegressor(loss=:tweedie, nrounds=5); x_train=xd, y_train=yd, verbosity=0), xd))
     end
 
+    @testset "non-finite target" begin
+        # A single NaN or Inf reached the initial bias and from there every gradient and leaf,
+        # so the fit reported its full tree count while predicting NaN everywhere. Only Gamma,
+        # Tweedie and Poisson checked their domain, and none of them looked for non-finite.
+        xd = rand(200, 3)
+        yd = 2 .* xd[:, 1] .+ 1
+        for bad in (NaN, Inf, -Inf), loss in (:mse, :poisson, :logloss)
+            y = copy(yd)
+            loss == :logloss && (y = Float64.(yd .> mean(yd)))
+            y[1] = bad
+            @test_throws ErrorException fit(EvoTreeRegressor(loss=loss, nrounds=2); x_train=xd, y_train=y, verbosity=0)
+        end
+        # matrix targets are checked on the same path
+        ym = hcat(yd, yd); ym[3, 2] = NaN
+        @test_throws ErrorException fit(EvoTreeRegressor(loss=:mse, nrounds=2); x_train=xd, y_train=ym, verbosity=0)
+        # a finite target still trains
+        @test all(isfinite, predict(fit(EvoTreeRegressor(loss=:mse, nrounds=5); x_train=xd, y_train=yd, verbosity=0), xd))
+    end
+
     @testset "check_args L2 and bagging_size" begin
         # Both used to be accepted unvalidated. A negative `L2` lands in the leaf denominator
         # and takes every prediction to NaN; a `bagging_size` below 1 makes the per-round loop


### PR DESCRIPTION
A single `NaN` or `Inf` in `y_train` reaches the initial bias and from there every gradient and every leaf, so `fit` returns normally, reports its full tree count, and predicts `NaN` everywhere.

One bad row in 20,000:

```
loss       result
:mse       fits, 30 trees, every prediction NaN
:poisson   fits, 30 trees, every prediction NaN
:gamma     errors (domain guard)
:tweedie   errors (domain guard)
```

`:gamma`, `:tweedie` and `:poisson` already check their domain in `_init_target`, but none of those checks looks for non-finite, and the losses without a domain constraint have no check at all. The guard goes in the same function, which is the shared entry point for both devices, and it names the offending value and index.

Tests cover `NaN`, `Inf` and `-Inf` across `:mse`, `:poisson` and `:logloss`, a matrix target, and a finite target still training.
