### PR TITLE
Thread the prediction row loop only when the batch is large enough to pay for it

### DIFF
--- a/src/predict.jl
+++ b/src/predict.jl
@@ -1,88 +1,90 @@
-function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L<:GradientRegression,K,T}
-    @threads for i in axes(x_bin, 1)
-        nid = 1
-        @inbounds while tree.split[nid]
-            feat = tree.feat[nid]
-            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
-            nid = nid << 1 + !cond
-        end
-        @inbounds for k in axes(pred, 1)
-            pred[k, i] += tree.pred[k, nid]
-        end
-    end
-    return nothing
-end
+"""
+    PREDICT_THREAD_MIN
 
-function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L<:LogLoss,K,T}
-    @threads for i in axes(x_bin, 1)
-        nid = 1
-        @inbounds while tree.split[nid]
-            feat = tree.feat[nid]
-            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
-            nid = nid << 1 + !cond
-        end
-        @inbounds for k in axes(pred, 1)
-            pred[k, i] = clamp(pred[k, i] + tree.pred[k, nid], T(-15), T(15))
-        end
-    end
-    return nothing
-end
-
-function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L<:MLE2P,K,T}
-    Y = size(pred, 1) ÷ 2
-    @threads for i in axes(x_bin, 1)
-        nid = 1
-        @inbounds while tree.split[nid]
-            feat = tree.feat[nid]
-            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
-            nid = nid << 1 + !cond
-        end
-        @inbounds for t in 1:Y
-            pred[2t-1, i] += tree.pred[2t-1, nid]
-            pred[2t, i] = max(T(-15), pred[2t, i] + tree.pred[2t, nid])
-        end
-    end
-    return nothing
-end
-
-function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L<:MLogLoss,K,T}
-    @threads for i in axes(x_bin, 1)
-        nid = 1
-        @inbounds while tree.split[nid]
-            feat = tree.feat[nid]
-            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
-            nid = nid << 1 + !cond
-        end
-        @inbounds for k = 1:K
-            pred[k, i] += tree.pred[k, nid]
-        end
-        @views pred[:, i] .= max.(T(-15), pred[:, i] .- maximum(pred[:, i]))
-    end
-    return nothing
-end
-function predict_leaf_index! end
-function _predict_leaf_indices end
+Row count below which `predict!` walks the batch serially. Threading the row loop opens a
+parallel region per tree, so a small batch pays that cost once per tree for a few rows of
+work. Measured on 200 trees at depth 5 with 8 threads: serial is 61x faster at 1 row, 6.9x
+at 64 and 1.9x at 256, while threading wins from roughly 1024.
+"""
+const PREDICT_THREAD_MIN = 512
 
 """
-    predict!(pred::Matrix, tree::Tree, X)
+    _leaf_index(tree, x_bin, feattypes, i)
 
-Generic fallback to add predictions of `tree` to existing `pred` matrix.
+Index of the leaf that row `i` falls into. Numeric and ordered features compare with `<=`,
+unordered categoricals with `==`.
+"""
+@inline function _leaf_index(tree::Tree, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int)
+    nid = 1
+    @inbounds while tree.split[nid]
+        feat = tree.feat[nid]
+        cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
+        nid = nid << 1 + !cond
+    end
+    return nid
+end
+
+@inline function _predict_row!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int) where {L<:GradientRegression,K,T}
+    nid = _leaf_index(tree, x_bin, feattypes, i)
+    @inbounds for k in axes(pred, 1)
+        pred[k, i] += tree.pred[k, nid]
+    end
+end
+
+@inline function _predict_row!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int) where {L<:LogLoss,K,T}
+    nid = _leaf_index(tree, x_bin, feattypes, i)
+    @inbounds for k in axes(pred, 1)
+        pred[k, i] = clamp(pred[k, i] + tree.pred[k, nid], T(-15), T(15))
+    end
+end
+
+@inline function _predict_row!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int) where {L<:MLE2P,K,T}
+    nid = _leaf_index(tree, x_bin, feattypes, i)
+    Y = size(pred, 1) ÷ 2
+    @inbounds for t in 1:Y
+        pred[2t-1, i] += tree.pred[2t-1, nid]
+        pred[2t, i] = max(T(-15), pred[2t, i] + tree.pred[2t, nid])
+    end
+end
+
+@inline function _predict_row!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int) where {L<:MLogLoss,K,T}
+    nid = _leaf_index(tree, x_bin, feattypes, i)
+    @inbounds for k = 1:K
+        pred[k, i] += tree.pred[k, nid]
+    end
+    @views pred[:, i] .= max.(T(-15), pred[:, i] .- maximum(pred[:, i]))
+end
+
+@inline function _predict_row!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}, i::Int) where {L,K,T}
+    nid = _leaf_index(tree, x_bin, feattypes, i)
+    @inbounds for k = 1:K
+        pred[k, i] += tree.pred[k, nid]
+    end
+end
+
+"""
+    predict!(pred::Matrix, tree::Tree, x_bin, feattypes)
+
+Add the predictions of `tree` to `pred`. The row loop is threaded only from
+`PREDICT_THREAD_MIN` rows up, since the parallel region is opened once per tree.
 """
 function predict!(pred::Matrix{T}, tree::Tree{L,K}, x_bin::Matrix{UInt8}, feattypes::Vector{Bool}) where {L,K,T}
-    @threads for i in axes(x_bin, 1)
-        nid = 1
-        @inbounds while tree.split[nid]
-            feat = tree.feat[nid]
-            cond = feattypes[feat] ? x_bin[i, feat] <= tree.cond_bin[nid] : x_bin[i, feat] == tree.cond_bin[nid]
-            nid = nid << 1 + !cond
+    n = size(x_bin, 1)
+    if n >= PREDICT_THREAD_MIN
+        @threads for i = 1:n
+            _predict_row!(pred, tree, x_bin, feattypes, i)
         end
-        @inbounds for k = 1:K
-            pred[k, i] += tree.pred[k, nid]
+    else
+        for i = 1:n
+            _predict_row!(pred, tree, x_bin, feattypes, i)
         end
     end
     return nothing
 end
 
+function predict_leaf_index! end
+
+function _predict_leaf_indices end
 
 """
     predict(m::EvoTree, data; ntree_limit=length(m.trees), device=:cpu)


### PR DESCRIPTION
`predict!` threads over rows and is called once per tree, so scoring opens a parallel region per tree. On a small batch that cost is paid in full for a few rows of work, and it dominates: a single row through a 200 tree model spends almost all of its time starting and joining threads rather than walking trees.

Measured on 200 trees at depth 5, 8 threads, median of 20 reps:

```
rows      before        after
     1    9192 us      36.5 us
    10   10007 us      90.1 us
   100   10597 us       622 us
  1000   12556 us      5134 us
 10000   21972 us     11476 us
100000   87647 us     88297 us
```

The row loop is now threaded from `PREDICT_THREAD_MIN` rows up and walks serially below it. The threshold is 512, from measuring both paths across batch sizes: serial is 61x faster at 1 row, 6.9x at 64 and 1.9x at 256, while threading wins from about 1024.

The five `predict!` methods only differed in what they do once the leaf is known, so the leaf walk moves to `_leaf_index` and each loss keeps a small `_predict_row!`. That leaves one row loop and one threading decision rather than five copies of each. The larger batches gain from that on their own, which is where the 1000 and 10000 row improvements come from; those still take the threaded path.

Predictions are unchanged: bit identical against `main` across `:mse`, `:logloss`, `:poisson`, `:quantile`, `gaussian_mle`, `:mlogloss` and a multi-target fit, at 1, 7, 511, 512, 5000 and 30000 rows.

`predict!` is also called per round from `grow_evotree!` and from the eval callback, so a small training or eval set benefits the same way. The GPU path defines its own `predict!` on device arrays and is untouched.
